### PR TITLE
Fix missing input field border

### DIFF
--- a/src/components/inputfield/index.js
+++ b/src/components/inputfield/index.js
@@ -64,7 +64,7 @@ const Wrapper = styled.div`
 `;
 
 const Input = styled.input`
-  -webkit-appearance: none; 
+  -webkit-appearance: none;
   font-family: 'Roboto', -apple-system, '.SFNSText-Regular', 'San Francisco', 'Segoe UI', 'Helvetica Neue',
     'Lucida Grande', sans-serif;
   width: 100%;

--- a/src/components/inputfield/index.js
+++ b/src/components/inputfield/index.js
@@ -64,6 +64,7 @@ const Wrapper = styled.div`
 `;
 
 const Input = styled.input`
+  -webkit-appearance: none; 
   font-family: 'Roboto', -apple-system, '.SFNSText-Regular', 'San Francisco', 'Segoe UI', 'Helvetica Neue',
     'Lucida Grande', sans-serif;
   width: 100%;


### PR DESCRIPTION
iPhone IOS will not display box-shadow property properly, in this case: setting `-webkit-appearance: none` on the custom `Input` component will solve the issue. 

Reference: https://stackoverflow.com/questions/10757146/iphone-ios-will-not-display-box-shadow-properly

Screenshot from my iPhone safari. (Works for chrome as well)
![image](https://user-images.githubusercontent.com/32864116/82433531-25ffa580-9ac4-11ea-9d3f-89f9160ddc78.png)
![image](https://user-images.githubusercontent.com/32864116/82433540-2a2bc300-9ac4-11ea-8b0d-bb6d987c8ccf.png)