### PR TITLE
Use Promise.all for non-dependent async functions

### DIFF
--- a/pages/wishes/[wishId].js
+++ b/pages/wishes/[wishId].js
@@ -16,12 +16,11 @@ export async function getServerSideProps({ params, req, res, query }) {
   const wishId = params.wishId;
   const prevHref = query.categoryId ? `/wishes/category/${query.categoryId}` : `/wishes/category`;
   const categoryName = query.categoryName ? query.categoryName : 'All wishes';
-  const wishDetails = await getWishDetails(wishId);
   let npoDetails = {}; // TODO remove & uncomment bottom when getNPO API is up
+  const [wishDetails, user] = await Promise.all([getWishDetails(wishId), isAuthenticated(req, res)]);
   if (Object.keys(wishDetails).length !== 0) {
     // npoDetails = await getNpoDetails(wishDetails.user.userId);
   }
-  let user = await isAuthenticated(req, res);
   return {
     props: {
       wishId,

--- a/pages/wishes/category/[categoryId].js
+++ b/pages/wishes/category/[categoryId].js
@@ -10,8 +10,7 @@ const TopNavigationBar = dynamic(() => import('../../../src/components/navbar/mo
 });
 
 export async function getServerSideProps({ params, query, req, res }) {
-  const categoryDetails = await getCategoryDetails(params.categoryId);
-  let user = await isAuthenticated(req, res);
+  const [categoryDetails, user] = await Promise.all([getCategoryDetails(params.categoryId), isAuthenticated(req, res)]);
   return {
     props: {
       categoryDetails,

--- a/utils/api/auth.js
+++ b/utils/api/auth.js
@@ -307,8 +307,10 @@ class AuthAPI {
     proofImage,
     activities
   ) {
-    const organizationInfo = await this._getCategoryInfo(organizationName);
-    const uploadedImage = await this._uploadNPOProofImage(userProfile.uid, proofImage);
+    const [organizationInfo, uploadedImage] = await Promise.all([
+      this._getCategoryInfo(organizationName),
+      this._uploadNPOProofImage(userProfile.uid, proofImage),
+    ]);
     const imagePath = uploadedImage.metadata.fullPath;
     const dateOfRegistration = dayOfRegistration + '-' + monthOfRegistration + '-' + yearOfRegistration;
 


### PR DESCRIPTION
There are consecutive calls to async functions using the `await` keyword. By using `Promise.all`, we can execute them concurrently while not interrupting the flow of the function. 