### PR TITLE
Potential fix for iphone auto zoom in 

### DIFF
--- a/src/components/chat/modules/ChatDialogInputRow.js
+++ b/src/components/chat/modules/ChatDialogInputRow.js
@@ -36,6 +36,16 @@ const StyledTextareaAutosize = styled(TextareaAutosize)`
   padding: 10px 10px;
   font-family: 'Trebuchet MS';
   resize: none;
+
+  /* 
+     To prevent auto zoom in on iphones, since inputs with font size that are less than 16px will be auto zoomed in.
+     Solution taken from: https://thingsthemselves.com/no-input-zoom-in-safari-on-iphone-the-pixel-perfect-way/
+   */
+  font-size: 16px;
+  width: 133.333333333%;
+  margin-right: calc(-33.333333333% + 48px) !important;
+  transform: scale(0.75);
+  transform-origin: left;
 `;
 
 const ChatDialogInputRow = ({ selectedChatId, setSelectedChatId, isNewChat, setIsNewChat, postType, postId }, ref) => {


### PR DESCRIPTION
Iphone auto zooms into input fields when the font size is less than 16px. 

A potential solution to this is to set the font size as 16px, and use the css scale function to scale down the font size.  Solution is taken from: https://thingsthemselves.com/no-input-zoom-in-safari-on-iphone-the-pixel-perfect-way/

Can't test it out so not 100% sure if it'll resolve the issue