### PR TITLE
Fix overflow of chat message

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -20,6 +20,7 @@ const GlobalStyle = createGlobalStyle`
     margin: 0;
     word-wrap: break-word;
     white-space: pre-wrap; 
+    word-break: break-word;
   }
 
   .default-avatar {


### PR DESCRIPTION
It is seen that sometimes when the sentences are too long, the words does not break to the next line, causing the overflow to make the wrong alignment of the chat bubble. (Seen below)

<img width="327" alt="Screen Shot 2020-07-19 at 11 37 19 PM" src="https://user-images.githubusercontent.com/32864116/87878777-054ac200-ca19-11ea-94ff-93a8e74cea45.png">

Let's add the `word-break: break-word` property to prevent that.
After:
<img width="332" alt="Screen Shot 2020-07-19 at 11 42 38 PM" src="https://user-images.githubusercontent.com/32864116/87878861-8ace7200-ca19-11ea-8ee9-f9e2ee33f685.png">
