### PR TITLE
Prevent images in chat to be longer than chat dialog messages height

### DIFF
--- a/src/components/chat/modules/ChatBubbleForImage.js
+++ b/src/components/chat/modules/ChatBubbleForImage.js
@@ -1,10 +1,15 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { colors } from '../../../../utils/constants/colors';
 
+// note that the max height of the image is set to 80% of the chat dialog messages' height,
+// to prevent any image message that is longer than the chat dialog height.
 const ChatBubbleImage = styled.img`
   max-width: min(400px, 90%);
-  width: fit-content;
+  width: auto;
+  height: auto;
+  max-height: calc(0.8 * ${({ messageContainerHeight }) => messageContainerHeight}px);
+  object-fit: cover;
   padding: 5px 5px 5px 5px;
   border-radius: 5px;
   background-color: ${(props) =>
@@ -15,9 +20,17 @@ const ChatBubbleImage = styled.img`
  *
  * @param {string} imageUrl is the imageUrl to display in the chat bubble
  * @param {string} isByLoggedInUser is whether the image is sent by logged in user
+ * @param {string} messageContainerHeight is the height of the ChatDialogMessages component
+ *
  */
-const ChatBubbleForImage = ({ imageUrl, isByLoggedInUser }) => {
-  return <ChatBubbleImage isByLoggedInUser={isByLoggedInUser} src={imageUrl} />;
+const ChatBubbleForImage = ({ imageUrl, isByLoggedInUser, messageContainerHeight }) => {
+  return (
+    <ChatBubbleImage
+      isByLoggedInUser={isByLoggedInUser}
+      src={imageUrl}
+      messageContainerHeight={messageContainerHeight}
+    />
+  );
 };
 
 export default ChatBubbleForImage;

--- a/src/components/chat/modules/ChatDialogMessages.js
+++ b/src/components/chat/modules/ChatDialogMessages.js
@@ -29,8 +29,8 @@ const mobileHeights = {
 
 const MessageContainer = styled.div`
   width: 100%;
-  min-height: calc(100vh - ${({ offsetHeight }) => offsetHeight}px);
-  max-height: calc(100vh - ${({ offsetHeight }) => offsetHeight}px);
+  min-height: ${({ messageContainerHeight }) => messageContainerHeight}px;
+  max-height: ${({ messageContainerHeight }) => messageContainerHeight}px;
   position: relative;
   overflow-y: scroll;
   overflow-x: hidden;
@@ -125,16 +125,21 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
     : mobileHeights;
 
   const sumOfOtherComponentHeights =
-    chatDialogBackButton + chatDialogSeePostRow + chatDialogUserRow + chatDialogMessagesPadding + inputRowHeight;
+    chatDialogBackButton +
+    chatDialogSeePostRow +
+    chatDialogUserRow +
+    chatDialogMessagesPadding +
+    inputRowHeight +
+    navBarHeight;
 
-  // offsetHeight is used to calculate the amount of height left for the ChatDialogMessages to occupy
-  const offsetHeight = navBarHeight + sumOfOtherComponentHeights;
+  // get the height left for the ChatDialogMessages component
+  const messageContainerHeight = window.innerHeight - sumOfOtherComponentHeights;
 
   // display tips before first message is being sent for a wish
   if (isNewChat && !selectedChatId && postType === wishes) {
     return (
       <CardSection>
-        <MessageContainer offsetHeight={offsetHeight}>
+        <MessageContainer messageContainerHeight={messageContainerHeight}>
           <NewChatTips postType={postType} />
         </MessageContainer>
       </CardSection>
@@ -143,7 +148,7 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
 
   return (
     <CardSection>
-      <MessageContainer offsetHeight={offsetHeight}>
+      <MessageContainer messageContainerHeight={messageContainerHeight}>
         <InfiniteScroll
           loadMore={handleOnSeeMore}
           hasMore={shouldSeeMore}
@@ -163,6 +168,7 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
                     message={message}
                     loggedInUser={loggedInUser}
                     selectedChatId={selectedChatId}
+                    messageContainerHeight={messageContainerHeight}
                   />
                 ) : (
                   <LeftMessageSection
@@ -170,6 +176,7 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
                     message={message}
                     loggedInUser={loggedInUser}
                     selectedChatId={selectedChatId}
+                    messageContainerHeight={messageContainerHeight}
                   />
                 );
               })}

--- a/src/components/chat/modules/ChatMessageSection.js
+++ b/src/components/chat/modules/ChatMessageSection.js
@@ -38,12 +38,26 @@ const LeftMessageSectionContainer = styled.div`
 /**
  * Gets the corresponding chat bubble based on message content type
  */
-const getMessageContent = (messageContentType, content, isByLoggedInUser, sender, loggedInUser, selectedChatId) => {
+const getMessageContent = (
+  messageContentType,
+  content,
+  isByLoggedInUser,
+  sender,
+  loggedInUser,
+  selectedChatId,
+  messageContainerHeight
+) => {
   if (messageContentType === 'text') {
     return <ChatBubbleForText text={content} isByLoggedInUser={isByLoggedInUser} />;
   }
   if (messageContentType === 'image') {
-    return <ChatBubbleForImage imageUrl={content} isByLoggedInUser={isByLoggedInUser} />;
+    return (
+      <ChatBubbleForImage
+        imageUrl={content}
+        isByLoggedInUser={isByLoggedInUser}
+        messageContainerHeight={messageContainerHeight}
+      />
+    );
   }
   if (messageContentType === 'calendar') {
     const dateTimes = content.split(','); // dateTimes are separated by comma delimiter
@@ -61,7 +75,7 @@ const getMessageContent = (messageContentType, content, isByLoggedInUser, sender
   return <div>N.A.</div>;
 };
 
-export const LeftMessageSection = ({ message, loggedInUser, selectedChatId }) => {
+export const LeftMessageSection = ({ message, loggedInUser, selectedChatId, messageContainerHeight }) => {
   const { content, sender, dateTime, contentType } = message;
   return (
     <LeftMessageSectionContainer>
@@ -69,7 +83,15 @@ export const LeftMessageSection = ({ message, loggedInUser, selectedChatId }) =>
         <ProfileAvatar imageUrl={sender.profileImageUrl.small || sender.profileImageUrl.raw} width={25} height={25} />
         <LeftColumnStackContainer>
           <Stack direction="column" spacing="extraTight">
-            {getMessageContent(contentType, content, false, sender, loggedInUser, selectedChatId)}
+            {getMessageContent(
+              contentType,
+              content,
+              false,
+              sender,
+              loggedInUser,
+              selectedChatId,
+              messageContainerHeight
+            )}
             <GreyText size="tiny">{getTimeDifferenceFromNow(dateTime)}</GreyText>
           </Stack>
         </LeftColumnStackContainer>
@@ -78,7 +100,7 @@ export const LeftMessageSection = ({ message, loggedInUser, selectedChatId }) =>
   );
 };
 
-export const RightMessageSection = ({ message, loggedInUser, selectedChatId }) => {
+export const RightMessageSection = ({ message, loggedInUser, selectedChatId, messageContainerHeight }) => {
   const { content, sender, dateTime, contentType } = message;
   return (
     <Stack direction="column" align="end" spaceAfter="none" grow={false}>
@@ -86,7 +108,15 @@ export const RightMessageSection = ({ message, loggedInUser, selectedChatId }) =
         <Stack direction="row">
           <RightColumnStackContainer>
             <Stack direction="column" spacing="extraTight" align="end">
-              {getMessageContent(contentType, content, true, sender, loggedInUser, selectedChatId)}
+              {getMessageContent(
+                contentType,
+                content,
+                true,
+                sender,
+                loggedInUser,
+                selectedChatId,
+                messageContainerHeight
+              )}
               <GreyText size="tiny">{getTimeDifferenceFromNow(dateTime)}</GreyText>
             </Stack>
           </RightColumnStackContainer>


### PR DESCRIPTION
Currently, users are able to send images with height that exceeds the message container's height. This might not be the best UX as user needs to scroll to see the full image.

Additionally, this issue potentially causes another issue pointed out by @kohchihao, where sending a long image shows a white space within the messages container.