### PR TITLE
Fix inconsistent scrolling to the bottom of chat messages

### DIFF
--- a/src/components/chat/modules/ChatDialogMessages.js
+++ b/src/components/chat/modules/ChatDialogMessages.js
@@ -79,16 +79,20 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
   };
 
   const updateChatMessages = (chatMessageDoc) => {
+    let isNewlySentMessage = false;
     setChatMessageDocs((prevChatMessageDocs) => {
       const newChatMessage = chatMessageDoc.data();
       const lastChatMessageDoc = prevChatMessageDocs[prevChatMessageDocs.length - 1];
-      // insert chat message doc to correct position
+      // insert chat message doc to the back if it is a newly sent message
       if (lastChatMessageDoc && lastChatMessageDoc.data().dateTime <= newChatMessage.dateTime) {
+        isNewlySentMessage = true;
         return [...prevChatMessageDocs, chatMessageDoc];
       }
       return [chatMessageDoc, ...prevChatMessageDocs];
     });
-    scrollToBottomIfSentByLoggedInUser(chatMessageDoc.data());
+    if (isNewlySentMessage) {
+      scrollToBottomIfSentByLoggedInUser(chatMessageDoc.data());
+    }
   };
 
   /**


### PR DESCRIPTION
Currently, it scrolls to the bottom of the chat messages if the incoming message is by the logged in user. This causes a scroll to bottom every time chat messages are updated, no matter it is older messages or new messages.

This pr allows only scroll to bottom of chat messages if it is a newly sent msg by logged in user.