### PR TITLE
Add missing return key word in styled component

### DIFF
--- a/src/components/chat/modules/ListOfChats.js
+++ b/src/components/chat/modules/ListOfChats.js
@@ -21,7 +21,7 @@ const ListOfChatsContainer = styled.div`
   overflow-y: scroll;
   border-right: 1px solid ${colors.chatBorders};
   display: ${({ isShow }) => {
-    isShow ? 'unset' : 'none';
+    return isShow ? 'unset' : 'none';
   }};
 `;
 


### PR DESCRIPTION
Without the return key word, nothing is being returned to the `display` property