### PR TITLE
Remove smooth scrolling in scrollIntoView

### DIFF
--- a/src/components/chat/modules/ChatDialogMessages.js
+++ b/src/components/chat/modules/ChatDialogMessages.js
@@ -74,7 +74,7 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
 
   const scrollToBottomIfSentByLoggedInUser = (chatMessage) => {
     if (messagesEndRef && messagesEndRef.current && chatMessage.sender.id === loggedInUser.user.userId) {
-      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
+      messagesEndRef.current.scrollIntoView();
     }
   };
 


### PR DESCRIPTION
Some mobile browsers do not support smooth scrolling in `scrollIntoView`, shown here: https://caniuse.com/#feat=scrollintoview