### PR TITLE
Remove use of window.innerHeight

### DIFF
--- a/src/components/chat/modules/ChatBubbleForImage.js
+++ b/src/components/chat/modules/ChatBubbleForImage.js
@@ -8,7 +8,7 @@ const ChatBubbleImage = styled.img`
   max-width: min(400px, 90%);
   width: auto;
   height: auto;
-  max-height: calc(0.8 * ${({ messageContainerHeight }) => messageContainerHeight}px);
+  max-height: calc(0.8 * calc(100vh - ${({ offsetHeight }) => offsetHeight}px));
   object-fit: cover;
   padding: 5px 5px 5px 5px;
   border-radius: 5px;
@@ -20,17 +20,12 @@ const ChatBubbleImage = styled.img`
  *
  * @param {string} imageUrl is the imageUrl to display in the chat bubble
  * @param {string} isByLoggedInUser is whether the image is sent by logged in user
- * @param {string} messageContainerHeight is the height of the ChatDialogMessages component
+ * @param {string} offsetHeight is the height occupied by other components in ChatDialog,
+ *                              except the ChatDialogMessages component
  *
  */
-const ChatBubbleForImage = ({ imageUrl, isByLoggedInUser, messageContainerHeight }) => {
-  return (
-    <ChatBubbleImage
-      isByLoggedInUser={isByLoggedInUser}
-      src={imageUrl}
-      messageContainerHeight={messageContainerHeight}
-    />
-  );
+const ChatBubbleForImage = ({ imageUrl, isByLoggedInUser, offsetHeight }) => {
+  return <ChatBubbleImage isByLoggedInUser={isByLoggedInUser} src={imageUrl} offsetHeight={offsetHeight} />;
 };
 
 export default ChatBubbleForImage;

--- a/src/components/chat/modules/ChatDialogMessages.js
+++ b/src/components/chat/modules/ChatDialogMessages.js
@@ -29,8 +29,8 @@ const mobileHeights = {
 
 const MessageContainer = styled.div`
   width: 100%;
-  min-height: ${({ messageContainerHeight }) => messageContainerHeight}px;
-  max-height: ${({ messageContainerHeight }) => messageContainerHeight}px;
+  min-height: calc(100vh - ${({ offsetHeight }) => offsetHeight}px);
+  max-height: calc(100vh - ${({ offsetHeight }) => offsetHeight}px);
   position: relative;
   overflow-y: scroll;
   overflow-x: hidden;
@@ -129,21 +129,15 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
     : mobileHeights;
 
   const sumOfOtherComponentHeights =
-    chatDialogBackButton +
-    chatDialogSeePostRow +
-    chatDialogUserRow +
-    chatDialogMessagesPadding +
-    inputRowHeight +
-    navBarHeight;
+    chatDialogBackButton + chatDialogSeePostRow + chatDialogUserRow + chatDialogMessagesPadding + inputRowHeight;
 
-  // get the height left for the ChatDialogMessages component
-  const messageContainerHeight = window.innerHeight - sumOfOtherComponentHeights;
+  const offsetHeight = navBarHeight + sumOfOtherComponentHeights;
 
   // display tips before first message is being sent for a wish
   if (isNewChat && !selectedChatId && postType === wishes) {
     return (
       <CardSection>
-        <MessageContainer messageContainerHeight={messageContainerHeight}>
+        <MessageContainer offsetHeight={offsetHeight}>
           <NewChatTips postType={postType} />
         </MessageContainer>
       </CardSection>
@@ -152,7 +146,7 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
 
   return (
     <CardSection>
-      <MessageContainer messageContainerHeight={messageContainerHeight}>
+      <MessageContainer offsetHeight={offsetHeight}>
         <InfiniteScroll
           loadMore={handleOnSeeMore}
           hasMore={shouldSeeMore}
@@ -172,7 +166,7 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
                     message={message}
                     loggedInUser={loggedInUser}
                     selectedChatId={selectedChatId}
-                    messageContainerHeight={messageContainerHeight}
+                    offsetHeight={offsetHeight}
                   />
                 ) : (
                   <LeftMessageSection
@@ -180,7 +174,7 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
                     message={message}
                     loggedInUser={loggedInUser}
                     selectedChatId={selectedChatId}
-                    messageContainerHeight={messageContainerHeight}
+                    offsetHeight={offsetHeight}
                   />
                 );
               })}

--- a/src/components/chat/modules/ChatMessageSection.js
+++ b/src/components/chat/modules/ChatMessageSection.js
@@ -45,19 +45,13 @@ const getMessageContent = (
   sender,
   loggedInUser,
   selectedChatId,
-  messageContainerHeight
+  offsetHeight
 ) => {
   if (messageContentType === 'text') {
     return <ChatBubbleForText text={content} isByLoggedInUser={isByLoggedInUser} />;
   }
   if (messageContentType === 'image') {
-    return (
-      <ChatBubbleForImage
-        imageUrl={content}
-        isByLoggedInUser={isByLoggedInUser}
-        messageContainerHeight={messageContainerHeight}
-      />
-    );
+    return <ChatBubbleForImage imageUrl={content} isByLoggedInUser={isByLoggedInUser} offsetHeight={offsetHeight} />;
   }
   if (messageContentType === 'calendar') {
     const dateTimes = content.split(','); // dateTimes are separated by comma delimiter
@@ -75,7 +69,7 @@ const getMessageContent = (
   return <div>N.A.</div>;
 };
 
-export const LeftMessageSection = ({ message, loggedInUser, selectedChatId, messageContainerHeight }) => {
+export const LeftMessageSection = ({ message, loggedInUser, selectedChatId, offsetHeight }) => {
   const { content, sender, dateTime, contentType } = message;
   return (
     <LeftMessageSectionContainer>
@@ -83,15 +77,7 @@ export const LeftMessageSection = ({ message, loggedInUser, selectedChatId, mess
         <ProfileAvatar imageUrl={sender.profileImageUrl.small || sender.profileImageUrl.raw} width={25} height={25} />
         <LeftColumnStackContainer>
           <Stack direction="column" spacing="extraTight">
-            {getMessageContent(
-              contentType,
-              content,
-              false,
-              sender,
-              loggedInUser,
-              selectedChatId,
-              messageContainerHeight
-            )}
+            {getMessageContent(contentType, content, false, sender, loggedInUser, selectedChatId, offsetHeight)}
             <GreyText size="tiny">{getTimeDifferenceFromNow(dateTime)}</GreyText>
           </Stack>
         </LeftColumnStackContainer>
@@ -100,7 +86,7 @@ export const LeftMessageSection = ({ message, loggedInUser, selectedChatId, mess
   );
 };
 
-export const RightMessageSection = ({ message, loggedInUser, selectedChatId, messageContainerHeight }) => {
+export const RightMessageSection = ({ message, loggedInUser, selectedChatId, offsetHeight }) => {
   const { content, sender, dateTime, contentType } = message;
   return (
     <Stack direction="column" align="end" spaceAfter="none" grow={false}>
@@ -108,15 +94,7 @@ export const RightMessageSection = ({ message, loggedInUser, selectedChatId, mes
         <Stack direction="row">
           <RightColumnStackContainer>
             <Stack direction="column" spacing="extraTight" align="end">
-              {getMessageContent(
-                contentType,
-                content,
-                true,
-                sender,
-                loggedInUser,
-                selectedChatId,
-                messageContainerHeight
-              )}
+              {getMessageContent(contentType, content, true, sender, loggedInUser, selectedChatId, offsetHeight)}
               <GreyText size="tiny">{getTimeDifferenceFromNow(dateTime)}</GreyText>
             </Stack>
           </RightColumnStackContainer>


### PR DESCRIPTION
Within #192, the height of the viewport is calculated in JS using `window.innerHeight`. However, `window.innerHeight` takes into account of the keyboard and it creates several UI issues.

Let's use `100vh` to get the viewport height instead.