### PR TITLE
Chat fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13269,6 +13269,15 @@
         "workbox-webpack-plugin": "4.3.1"
       }
     },
+    "react-stay-scrolled": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/react-stay-scrolled/-/react-stay-scrolled-7.1.0.tgz",
+      "integrity": "sha512-/rIsHqTnSwMs6crYL+AoFfxBIH5iUNE+EqbOF+cSNyGoTvweQCKWaOqey8wKwDysld+X4HLPqQnobSAzKoAUgA==",
+      "requires": {
+        "memoize-one": "^5.1.1",
+        "tiny-invariant": "^1.1.0"
+      }
+    },
     "react-textarea-autosize": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13124,14 +13124,6 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
-    "react-infinite-scroller": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/react-infinite-scroller/-/react-infinite-scroller-1.2.4.tgz",
-      "integrity": "sha512-/oOa0QhZjXPqaD6sictN2edFMsd3kkMiE19Vcz5JDgHpzEJVqYcmq+V3mkwO88087kvKGe1URNksHEOt839Ubw==",
-      "requires": {
-        "prop-types": "^15.5.8"
-      }
-    },
     "react-instantsearch-core": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.6.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13085,6 +13085,14 @@
         }
       }
     },
+    "react-device-detect": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-1.13.1.tgz",
+      "integrity": "sha512-XTPgAMsUVHC5lMNUGiAeO2UfAfhMfjq0CBUM67eHnc9XfO7iESh6h/cffKV8VGgrZBX+dyuqJl23bLLHoav5Ig==",
+      "requires": {
+        "ua-parser-js": "^0.7.21"
+      }
+    },
     "react-dom": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
@@ -15429,6 +15437,11 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "ua-parser-js": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
     },
     "uc.micro": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "next-redux-wrapper": "^6.0.0",
     "react": "^16.13.1",
     "react-beautiful-dnd": "^13.0.0",
+    "react-device-detect": "^1.13.1",
     "react-dom": "^16.13.1",
     "react-dropzone": "^11.0.1",
     "react-instantsearch-dom": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-redux": "^7.2.0",
     "react-responsive-carousel": "^3.2.7",
     "react-scripts": "3.4.0",
+    "react-stay-scrolled": "^7.1.0",
     "react-textarea-autosize": "^8.2.0",
     "react-tiny-popover": "^5.1.0",
     "react-toastify": "^6.0.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "react-beautiful-dnd": "^13.0.0",
     "react-dom": "^16.13.1",
     "react-dropzone": "^11.0.1",
-    "react-infinite-scroller": "^1.2.4",
     "react-instantsearch-dom": "^6.6.0",
     "react-linkify": "^1.0.0-alpha",
     "react-measure": "^2.3.0",

--- a/src/components/chat/modules/ChatDialog.js
+++ b/src/components/chat/modules/ChatDialog.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Measure from 'react-measure';
 import { Stack, ButtonLink } from '@kiwicom/orbit-components/lib';
 import ChatDialogUserRow from './ChatDialogUserRow';
@@ -42,6 +42,7 @@ const ChatDialogContent = ({
   // default as 68 px which is single line text area, modified when there
   // is more than one line in the text area in input row
   const [inputRowHeight, setInputRowHeight] = useState(68);
+  const chatDialogEndRef = useRef(null);
 
   let chatPostTitle, oppositeUser, chatPostType, chatPostId, postOwnerId, postEnquirerId, postStatus;
   const isCreatingNewChatForAPost = postId !== null && isNewChat;
@@ -65,6 +66,10 @@ const ChatDialogContent = ({
     postEnquirerId = chatPostType === donations ? chat.npo.id : chat.donor.id;
     postStatus = chat.post.status;
   }
+
+  useEffect(() => {
+    chatDialogEndRef.current.scrollIntoView();
+  }, []);
 
   return (
     <>
@@ -118,6 +123,7 @@ const ChatDialogContent = ({
           />
         )}
       </Measure>
+      <div ref={chatDialogEndRef} />
     </>
   );
 };

--- a/src/components/chat/modules/ChatDialogInputRow.js
+++ b/src/components/chat/modules/ChatDialogInputRow.js
@@ -9,6 +9,7 @@ import media from '@kiwicom/orbit-components/lib/utils/mediaQuery';
 import TextareaAutosize from 'react-textarea-autosize';
 import { useRouter } from 'next/router';
 import useMediaQuery from '@kiwicom/orbit-components/lib/hooks/useMediaQuery';
+import { isMobile } from 'react-device-detect';
 
 const InputRowContainer = styled.div`
   width: 95%;
@@ -91,7 +92,8 @@ const ChatDialogInputRow = ({ selectedChatId, setSelectedChatId, isNewChat, setI
   const handleEnterInputter = (event) => {
     // enter pressed, send message (except shift + enter)
     if (event.keyCode == 13) {
-      if (!event.shiftKey) {
+      // only send message when press enter on desktop without holding shift key
+      if (!event.shiftKey && !isMobile) {
         event.preventDefault(); // prevent enter from adding a new line in text area
         handleSendTextMessage();
       }

--- a/src/components/chat/modules/ChatDialogMessages.js
+++ b/src/components/chat/modules/ChatDialogMessages.js
@@ -9,6 +9,7 @@ import InfiniteScroll from '../../scroller/InfiniteScroller';
 import { wishes } from '../../../../utils/constants/postType';
 import { CHAT_MESSAGES_BATCH_SIZE } from '../../../../utils/api/constants';
 import { LeftMessageSection, RightMessageSection } from './ChatMessageSection';
+import useStayScrolled from 'react-stay-scrolled';
 
 /**
  * To be changed if any of the heights change, the extra "+1 or +2" for the top/bottom borders
@@ -48,6 +49,8 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
   // to have messages initially
   const [shouldSeeMore, setShouldSeeMore] = useState(!isNewChat);
   const { isTablet } = useMediaQuery();
+  const scrollerRef = useRef(null);
+  const { stayScrolled, scrollBottom } = useStayScrolled(scrollerRef);
 
   useEffect(() => {
     // reset values every time selectedChatId changes
@@ -70,11 +73,9 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
     };
   }, [selectedChatId]);
 
-  const messagesEndRef = useRef(null); // to keep track of the bottom of the messages
-
   const scrollToBottomIfSentByLoggedInUser = (chatMessage) => {
-    if (messagesEndRef && messagesEndRef.current && chatMessage.sender.id === loggedInUser.user.userId) {
-      messagesEndRef.current.scrollIntoView();
+    if (chatMessage.sender.id === loggedInUser.user.userId) {
+      scrollBottom();
     }
   };
 
@@ -119,6 +120,7 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
         // loaded all chat messages
         setShouldSeeMore(false);
       }
+      stayScrolled(); // so that adding new messages won't shift the scroll position
     });
   };
 
@@ -146,7 +148,7 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
 
   return (
     <CardSection>
-      <MessageContainer offsetHeight={offsetHeight}>
+      <MessageContainer offsetHeight={offsetHeight} ref={scrollerRef}>
         <InfiniteScroll
           loadMore={handleOnSeeMore}
           hasMore={shouldSeeMore}
@@ -178,7 +180,6 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
                   />
                 );
               })}
-            <div ref={messagesEndRef} />
           </Stack>
         </InfiniteScroll>
       </MessageContainer>

--- a/src/components/chat/modules/ChatDialogMessages.js
+++ b/src/components/chat/modules/ChatDialogMessages.js
@@ -139,7 +139,7 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
   if (isNewChat && !selectedChatId && postType === wishes) {
     return (
       <CardSection>
-        <MessageContainer offsetHeight={offsetHeight}>
+        <MessageContainer offsetHeight={offsetHeight} ref={scrollerRef}>
           <NewChatTips postType={postType} />
         </MessageContainer>
       </CardSection>

--- a/src/components/chat/modules/ChatDialogMessages.js
+++ b/src/components/chat/modules/ChatDialogMessages.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { CardSection } from '@kiwicom/orbit-components/lib/Card';
 import useMediaQuery from '@kiwicom/orbit-components/lib/hooks/useMediaQuery';
 import NewChatTips from './NewChatTipsForWish';
-import InfiniteScroll from 'react-infinite-scroller';
+import InfiniteScroll from '../../scroller/InfiniteScroller';
 import { wishes } from '../../../../utils/constants/postType';
 import { CHAT_MESSAGES_BATCH_SIZE } from '../../../../utils/api/constants';
 import { LeftMessageSection, RightMessageSection } from './ChatMessageSection';

--- a/src/components/chat/modules/ListOfChats.js
+++ b/src/components/chat/modules/ListOfChats.js
@@ -6,7 +6,7 @@ import styled, { css } from 'styled-components';
 import media from '@kiwicom/orbit-components/lib/utils/mediaQuery';
 import { colors } from '../../../../utils/constants/colors';
 import { MODIFIED, ADDED } from '../../../../utils/constants/chatSubscriptionChange';
-import InfiniteScroll from 'react-infinite-scroller';
+import InfiniteScroll from '../../scroller/InfiniteScroller';
 import { USER_CHATS_BATCH_SIZE } from '../../../../utils/api/constants';
 
 const ListOfChatsContainer = styled.div`

--- a/src/components/profile/modules/PastDonationsPanel.js
+++ b/src/components/profile/modules/PastDonationsPanel.js
@@ -7,7 +7,7 @@ import media from '@kiwicom/orbit-components/lib/utils/mediaQuery';
 import SeeMoreButtonStyle from '../../buttons/SeeMoreButton';
 import BlackText from '../../text/BlackText';
 import { DONATIONS_BATCH_SIZE } from '../../../../utils/api/constants';
-import InfiniteScroll from 'react-infinite-scroller';
+import InfiniteScroll from '../../scroller/InfiniteScroller';
 import useMediaQuery from '@kiwicom/orbit-components/lib/hooks/useMediaQuery';
 import { getFormattedDate } from '../../../../utils/api/time';
 

--- a/src/components/profile/modules/PastWishesPanel.js
+++ b/src/components/profile/modules/PastWishesPanel.js
@@ -7,7 +7,7 @@ import media from '@kiwicom/orbit-components/lib/utils/mediaQuery';
 import SeeMoreButtonStyle from '../../buttons/SeeMoreButton';
 import BlackText from '../../text/BlackText';
 import { WISHES_BATCH_SIZE } from '../../../../utils/api/constants';
-import InfiniteScroll from 'react-infinite-scroller';
+import InfiniteScroll from '../../scroller/InfiniteScroller';
 import useMediaQuery from '@kiwicom/orbit-components/lib/hooks/useMediaQuery';
 
 const GridSectionContainer = styled.div`

--- a/src/components/scroller/InfiniteScroller.js
+++ b/src/components/scroller/InfiniteScroller.js
@@ -1,3 +1,8 @@
+/**
+ * Credits to @danbovey with his infinite scroller implementation here: 
+ * https://github.com/danbovey/react-infinite-scroller
+ */
+
 'use strict';
 
 Object.defineProperty(exports, '__esModule', {

--- a/src/components/scroller/InfiniteScroller.js
+++ b/src/components/scroller/InfiniteScroller.js
@@ -1,0 +1,393 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true,
+});
+
+var _createClass = (function () {
+  function defineProperties(target, props) {
+    for (var i = 0; i < props.length; i++) {
+      var descriptor = props[i];
+      descriptor.enumerable = descriptor.enumerable || false;
+      descriptor.configurable = true;
+      if ('value' in descriptor) descriptor.writable = true;
+      Object.defineProperty(target, descriptor.key, descriptor);
+    }
+  }
+  return function (Constructor, protoProps, staticProps) {
+    if (protoProps) defineProperties(Constructor.prototype, protoProps);
+    if (staticProps) defineProperties(Constructor, staticProps);
+    return Constructor;
+  };
+})();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : { default: obj };
+}
+
+function _objectWithoutProperties(obj, keys) {
+  var target = {};
+  for (var i in obj) {
+    if (keys.indexOf(i) >= 0) continue;
+    if (!Object.prototype.hasOwnProperty.call(obj, i)) continue;
+    target[i] = obj[i];
+  }
+  return target;
+}
+
+function _classCallCheck(instance, Constructor) {
+  if (!(instance instanceof Constructor)) {
+    throw new TypeError('Cannot call a class as a function');
+  }
+}
+
+function _possibleConstructorReturn(self, call) {
+  if (!self) {
+    throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
+  }
+  return call && (typeof call === 'object' || typeof call === 'function') ? call : self;
+}
+
+function _inherits(subClass, superClass) {
+  if (typeof superClass !== 'function' && superClass !== null) {
+    throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass);
+  }
+  subClass.prototype = Object.create(superClass && superClass.prototype, {
+    constructor: { value: subClass, enumerable: false, writable: true, configurable: true },
+  });
+  if (superClass)
+    Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : (subClass.__proto__ = superClass);
+}
+
+var InfiniteScroll = (function (_Component) {
+  _inherits(InfiniteScroll, _Component);
+
+  function InfiniteScroll(props) {
+    _classCallCheck(this, InfiniteScroll);
+
+    var _this = _possibleConstructorReturn(
+      this,
+      (InfiniteScroll.__proto__ || Object.getPrototypeOf(InfiniteScroll)).call(this, props)
+    );
+
+    _this.scrollListener = _this.scrollListener.bind(_this);
+    _this.eventListenerOptions = _this.eventListenerOptions.bind(_this);
+    _this.mousewheelListener = _this.mousewheelListener.bind(_this);
+    return _this;
+  }
+
+  _createClass(InfiniteScroll, [
+    {
+      key: 'componentDidMount',
+      value: function componentDidMount() {
+        this.pageLoaded = this.props.pageStart;
+        this.options = this.eventListenerOptions();
+        this.attachScrollListener();
+      },
+    },
+    {
+      key: 'componentDidUpdate',
+      value: function componentDidUpdate() {
+        if (this.props.isReverse && this.loadMore) {
+          var parentElement = this.getParentElement(this.scrollComponent);
+          parentElement.scrollTop = parentElement.scrollHeight - this.beforeScrollHeight + this.beforeScrollTop;
+          this.loadMore = false;
+        }
+        this.attachScrollListener();
+      },
+    },
+    {
+      key: 'componentWillUnmount',
+      value: function componentWillUnmount() {
+        this.detachScrollListener();
+        this.detachMousewheelListener();
+      },
+    },
+    {
+      key: 'isPassiveSupported',
+      value: function isPassiveSupported() {
+        var passive = false;
+
+        var testOptions = {
+          get passive() {
+            passive = true;
+          },
+        };
+
+        try {
+          document.addEventListener('test', null, testOptions);
+          document.removeEventListener('test', null, testOptions);
+        } catch (e) {
+          // ignore
+        }
+        return passive;
+      },
+    },
+    {
+      key: 'eventListenerOptions',
+      value: function eventListenerOptions() {
+        var options = this.props.useCapture;
+
+        if (this.isPassiveSupported()) {
+          options = {
+            useCapture: this.props.useCapture,
+            passive: true,
+          };
+        }
+        return options;
+      },
+
+      // Set a defaut loader for all your `InfiniteScroll` components
+    },
+    {
+      key: 'setDefaultLoader',
+      value: function setDefaultLoader(loader) {
+        this.defaultLoader = loader;
+      },
+    },
+    {
+      key: 'detachMousewheelListener',
+      value: function detachMousewheelListener() {
+        var scrollEl = window;
+        if (this.props.useWindow === false) {
+          scrollEl = this.scrollComponent.parentNode;
+        }
+
+        scrollEl.removeEventListener(
+          'mousewheel',
+          this.mousewheelListener,
+          this.options ? this.options : this.props.useCapture
+        );
+      },
+    },
+    {
+      key: 'detachScrollListener',
+      value: function detachScrollListener() {
+        var scrollEl = window;
+        if (this.props.useWindow === false) {
+          scrollEl = this.getParentElement(this.scrollComponent);
+        }
+
+        scrollEl.removeEventListener(
+          'scroll',
+          this.scrollListener,
+          this.options ? this.options : this.props.useCapture
+        );
+        scrollEl.removeEventListener(
+          'resize',
+          this.scrollListener,
+          this.options ? this.options : this.props.useCapture
+        );
+      },
+    },
+    {
+      key: 'getParentElement',
+      value: function getParentElement(el) {
+        var scrollParent = this.props.getScrollParent && this.props.getScrollParent();
+        if (scrollParent != null) {
+          return scrollParent;
+        }
+        return el && el.parentNode;
+      },
+    },
+    {
+      key: 'filterProps',
+      value: function filterProps(props) {
+        return props;
+      },
+    },
+    {
+      key: 'attachScrollListener',
+      value: function attachScrollListener() {
+        var parentElement = this.getParentElement(this.scrollComponent);
+
+        if (!this.props.hasMore || !parentElement) {
+          return;
+        }
+
+        var scrollEl = window;
+        if (this.props.useWindow === false) {
+          scrollEl = parentElement;
+        }
+
+        scrollEl.addEventListener(
+          'mousewheel',
+          this.mousewheelListener,
+          this.options ? this.options : this.props.useCapture
+        );
+        scrollEl.addEventListener('scroll', this.scrollListener, this.options ? this.options : this.props.useCapture);
+        scrollEl.addEventListener('resize', this.scrollListener, this.options ? this.options : this.props.useCapture);
+
+        if (this.props.initialLoad) {
+          this.scrollListener();
+        }
+      },
+    },
+    {
+      key: 'mousewheelListener',
+      value: function mousewheelListener(e) {
+        // Prevents Chrome hangups
+        // See: https://stackoverflow.com/questions/47524205/random-high-content-download-time-in-chrome/47684257#47684257
+        if (e.deltaY === 1 && !this.isPassiveSupported()) {
+          e.preventDefault();
+        }
+      },
+    },
+    {
+      key: 'scrollListener',
+      value: function scrollListener() {
+        var el = this.scrollComponent;
+        var scrollEl = window;
+        var parentNode = this.getParentElement(el);
+
+        var offset = void 0;
+        if (this.props.useWindow) {
+          var doc = document.documentElement || document.body.parentNode || document.body;
+          var scrollTop = scrollEl.pageYOffset !== undefined ? scrollEl.pageYOffset : doc.scrollTop;
+          if (this.props.isReverse) {
+            offset = scrollTop;
+          } else {
+            offset = this.calculateOffset(el, scrollTop);
+          }
+        } else if (this.props.isReverse) {
+          if (parentNode.scrollTop >= 0) {
+            offset = parentNode.scrollTop;
+          } else {
+            // known issue with safari:
+            // scrollTop will be a negative value instead of positive, need to handle separately
+            // reference: https://bugzilla.mozilla.org/show_bug.cgi?id=1042151#c36
+            offset = parentNode.scrollHeight + parentNode.scrollTop - parentNode.clientHeight;
+          }
+        } else {
+          offset = el.scrollHeight - parentNode.scrollTop - parentNode.clientHeight;
+        }
+
+        // Here we make sure the element is visible as well as checking the offset
+        if (offset < Number(this.props.threshold) && el && el.offsetParent !== null) {
+          this.detachScrollListener();
+          this.beforeScrollHeight = parentNode.scrollHeight;
+          this.beforeScrollTop = parentNode.scrollTop;
+          // Call loadMore after detachScrollListener to allow for non-async loadMore functions
+          if (typeof this.props.loadMore === 'function') {
+            this.props.loadMore((this.pageLoaded += 1));
+            this.loadMore = true;
+          }
+        }
+      },
+    },
+    {
+      key: 'calculateOffset',
+      value: function calculateOffset(el, scrollTop) {
+        if (!el) {
+          return 0;
+        }
+
+        return this.calculateTopPosition(el) + (el.offsetHeight - scrollTop - window.innerHeight);
+      },
+    },
+    {
+      key: 'calculateTopPosition',
+      value: function calculateTopPosition(el) {
+        if (!el) {
+          return 0;
+        }
+        return el.offsetTop + this.calculateTopPosition(el.offsetParent);
+      },
+    },
+    {
+      key: 'render',
+      value: function render() {
+        var _this2 = this;
+
+        var renderProps = this.filterProps(this.props);
+
+        var children = renderProps.children,
+          element = renderProps.element,
+          hasMore = renderProps.hasMore,
+          initialLoad = renderProps.initialLoad,
+          isReverse = renderProps.isReverse,
+          loader = renderProps.loader,
+          loadMore = renderProps.loadMore,
+          pageStart = renderProps.pageStart,
+          ref = renderProps.ref,
+          threshold = renderProps.threshold,
+          useCapture = renderProps.useCapture,
+          useWindow = renderProps.useWindow,
+          getScrollParent = renderProps.getScrollParent,
+          props = _objectWithoutProperties(renderProps, [
+            'children',
+            'element',
+            'hasMore',
+            'initialLoad',
+            'isReverse',
+            'loader',
+            'loadMore',
+            'pageStart',
+            'ref',
+            'threshold',
+            'useCapture',
+            'useWindow',
+            'getScrollParent',
+          ]);
+
+        props.ref = function (node) {
+          _this2.scrollComponent = node;
+          if (ref) {
+            ref(node);
+          }
+        };
+
+        var childrenArray = [children];
+        if (hasMore) {
+          if (loader) {
+            isReverse ? childrenArray.unshift(loader) : childrenArray.push(loader);
+          } else if (this.defaultLoader) {
+            isReverse ? childrenArray.unshift(this.defaultLoader) : childrenArray.push(this.defaultLoader);
+          }
+        }
+        return _react2.default.createElement(element, props, childrenArray);
+      },
+    },
+  ]);
+
+  return InfiniteScroll;
+})(_react.Component);
+
+InfiniteScroll.propTypes = {
+  children: _propTypes2.default.node.isRequired,
+  element: _propTypes2.default.node,
+  hasMore: _propTypes2.default.bool,
+  initialLoad: _propTypes2.default.bool,
+  isReverse: _propTypes2.default.bool,
+  loader: _propTypes2.default.node,
+  loadMore: _propTypes2.default.func.isRequired,
+  pageStart: _propTypes2.default.number,
+  ref: _propTypes2.default.func,
+  getScrollParent: _propTypes2.default.func,
+  threshold: _propTypes2.default.number,
+  useCapture: _propTypes2.default.bool,
+  useWindow: _propTypes2.default.bool,
+};
+InfiniteScroll.defaultProps = {
+  element: 'div',
+  hasMore: false,
+  initialLoad: true,
+  pageStart: 0,
+  ref: null,
+  threshold: 250,
+  useWindow: true,
+  isReverse: false,
+  useCapture: false,
+  loader: null,
+  getScrollParent: null,
+};
+exports.default = InfiniteScroll;
+module.exports = exports['default'];

--- a/src/components/scroller/InfiniteScroller.js
+++ b/src/components/scroller/InfiniteScroller.js
@@ -1,5 +1,5 @@
 /**
- * Credits to @danbovey with his infinite scroller implementation here: 
+ * Credits to @danbovey with his infinite scroller implementation here:
  * https://github.com/danbovey/react-infinite-scroller
  */
 

--- a/src/components/scroller/InfiniteScroller.js
+++ b/src/components/scroller/InfiniteScroller.js
@@ -3,396 +3,264 @@
  * https://github.com/danbovey/react-infinite-scroller
  */
 
-'use strict';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
-Object.defineProperty(exports, '__esModule', {
-  value: true,
-});
+export default class InfiniteScroll extends Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    element: PropTypes.node,
+    hasMore: PropTypes.bool,
+    initialLoad: PropTypes.bool,
+    isReverse: PropTypes.bool,
+    loader: PropTypes.node,
+    loadMore: PropTypes.func.isRequired,
+    pageStart: PropTypes.number,
+    ref: PropTypes.func,
+    getScrollParent: PropTypes.func,
+    threshold: PropTypes.number,
+    useCapture: PropTypes.bool,
+    useWindow: PropTypes.bool,
+  };
 
-var _createClass = (function () {
-  function defineProperties(target, props) {
-    for (var i = 0; i < props.length; i++) {
-      var descriptor = props[i];
-      descriptor.enumerable = descriptor.enumerable || false;
-      descriptor.configurable = true;
-      if ('value' in descriptor) descriptor.writable = true;
-      Object.defineProperty(target, descriptor.key, descriptor);
+  static defaultProps = {
+    element: 'div',
+    hasMore: false,
+    initialLoad: true,
+    pageStart: 0,
+    ref: null,
+    threshold: 250,
+    useWindow: true,
+    isReverse: false,
+    useCapture: false,
+    loader: null,
+    getScrollParent: null,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.scrollListener = this.scrollListener.bind(this);
+    this.eventListenerOptions = this.eventListenerOptions.bind(this);
+    this.mousewheelListener = this.mousewheelListener.bind(this);
+  }
+
+  componentDidMount() {
+    this.pageLoaded = this.props.pageStart;
+    this.options = this.eventListenerOptions();
+    this.attachScrollListener();
+  }
+
+  componentDidUpdate() {
+    if (this.props.isReverse && this.loadMore) {
+      const parentElement = this.getParentElement(this.scrollComponent);
+      parentElement.scrollTop = parentElement.scrollHeight - this.beforeScrollHeight + this.beforeScrollTop;
+      this.loadMore = false;
+    }
+    this.attachScrollListener();
+  }
+
+  componentWillUnmount() {
+    this.detachScrollListener();
+    this.detachMousewheelListener();
+  }
+
+  isPassiveSupported() {
+    let passive = false;
+
+    const testOptions = {
+      get passive() {
+        passive = true;
+      },
+    };
+
+    try {
+      document.addEventListener('test', null, testOptions);
+      document.removeEventListener('test', null, testOptions);
+    } catch (e) {
+      // ignore
+    }
+    return passive;
+  }
+
+  eventListenerOptions() {
+    let options = this.props.useCapture;
+
+    if (this.isPassiveSupported()) {
+      options = {
+        useCapture: this.props.useCapture,
+        passive: true,
+      };
+    } else {
+      options = {
+        passive: false,
+      };
+    }
+    return options;
+  }
+
+  // Set a defaut loader for all your `InfiniteScroll` components
+  setDefaultLoader(loader) {
+    this.defaultLoader = loader;
+  }
+
+  detachMousewheelListener() {
+    let scrollEl = window;
+    if (this.props.useWindow === false) {
+      scrollEl = this.scrollComponent.parentNode;
+    }
+
+    scrollEl.removeEventListener(
+      'mousewheel',
+      this.mousewheelListener,
+      this.options ? this.options : this.props.useCapture
+    );
+  }
+
+  detachScrollListener() {
+    let scrollEl = window;
+    if (this.props.useWindow === false) {
+      scrollEl = this.getParentElement(this.scrollComponent);
+    }
+
+    scrollEl.removeEventListener('scroll', this.scrollListener, this.options ? this.options : this.props.useCapture);
+    scrollEl.removeEventListener('resize', this.scrollListener, this.options ? this.options : this.props.useCapture);
+  }
+
+  getParentElement(el) {
+    const scrollParent = this.props.getScrollParent && this.props.getScrollParent();
+    if (scrollParent != null) {
+      return scrollParent;
+    }
+    return el && el.parentNode;
+  }
+
+  filterProps(props) {
+    return props;
+  }
+
+  attachScrollListener() {
+    const parentElement = this.getParentElement(this.scrollComponent);
+
+    if (!this.props.hasMore || !parentElement) {
+      return;
+    }
+
+    let scrollEl = window;
+    if (this.props.useWindow === false) {
+      scrollEl = parentElement;
+    }
+
+    scrollEl.addEventListener(
+      'mousewheel',
+      this.mousewheelListener,
+      this.options ? this.options : this.props.useCapture
+    );
+    scrollEl.addEventListener('scroll', this.scrollListener, this.options ? this.options : this.props.useCapture);
+    scrollEl.addEventListener('resize', this.scrollListener, this.options ? this.options : this.props.useCapture);
+
+    if (this.props.initialLoad) {
+      this.scrollListener();
     }
   }
-  return function (Constructor, protoProps, staticProps) {
-    if (protoProps) defineProperties(Constructor.prototype, protoProps);
-    if (staticProps) defineProperties(Constructor, staticProps);
-    return Constructor;
-  };
-})();
 
-var _react = require('react');
-
-var _react2 = _interopRequireDefault(_react);
-
-var _propTypes = require('prop-types');
-
-var _propTypes2 = _interopRequireDefault(_propTypes);
-
-function _interopRequireDefault(obj) {
-  return obj && obj.__esModule ? obj : { default: obj };
-}
-
-function _objectWithoutProperties(obj, keys) {
-  var target = {};
-  for (var i in obj) {
-    if (keys.indexOf(i) >= 0) continue;
-    if (!Object.prototype.hasOwnProperty.call(obj, i)) continue;
-    target[i] = obj[i];
-  }
-  return target;
-}
-
-function _classCallCheck(instance, Constructor) {
-  if (!(instance instanceof Constructor)) {
-    throw new TypeError('Cannot call a class as a function');
-  }
-}
-
-function _possibleConstructorReturn(self, call) {
-  if (!self) {
-    throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
-  }
-  return call && (typeof call === 'object' || typeof call === 'function') ? call : self;
-}
-
-function _inherits(subClass, superClass) {
-  if (typeof superClass !== 'function' && superClass !== null) {
-    throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass);
-  }
-  subClass.prototype = Object.create(superClass && superClass.prototype, {
-    constructor: { value: subClass, enumerable: false, writable: true, configurable: true },
-  });
-  if (superClass)
-    Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : (subClass.__proto__ = superClass);
-}
-
-var InfiniteScroll = (function (_Component) {
-  _inherits(InfiniteScroll, _Component);
-
-  function InfiniteScroll(props) {
-    _classCallCheck(this, InfiniteScroll);
-
-    var _this = _possibleConstructorReturn(
-      this,
-      (InfiniteScroll.__proto__ || Object.getPrototypeOf(InfiniteScroll)).call(this, props)
-    );
-
-    _this.scrollListener = _this.scrollListener.bind(_this);
-    _this.eventListenerOptions = _this.eventListenerOptions.bind(_this);
-    _this.mousewheelListener = _this.mousewheelListener.bind(_this);
-    return _this;
+  mousewheelListener(e) {
+    // Prevents Chrome hangups
+    // See: https://stackoverflow.com/questions/47524205/random-high-content-download-time-in-chrome/47684257#47684257
+    if (e.deltaY === 1 && !this.isPassiveSupported()) {
+      e.preventDefault();
+    }
   }
 
-  _createClass(InfiniteScroll, [
-    {
-      key: 'componentDidMount',
-      value: function componentDidMount() {
-        this.pageLoaded = this.props.pageStart;
-        this.options = this.eventListenerOptions();
-        this.attachScrollListener();
-      },
-    },
-    {
-      key: 'componentDidUpdate',
-      value: function componentDidUpdate() {
-        if (this.props.isReverse && this.loadMore) {
-          var parentElement = this.getParentElement(this.scrollComponent);
-          parentElement.scrollTop = parentElement.scrollHeight - this.beforeScrollHeight + this.beforeScrollTop;
-          this.loadMore = false;
-        }
-        this.attachScrollListener();
-      },
-    },
-    {
-      key: 'componentWillUnmount',
-      value: function componentWillUnmount() {
-        this.detachScrollListener();
-        this.detachMousewheelListener();
-      },
-    },
-    {
-      key: 'isPassiveSupported',
-      value: function isPassiveSupported() {
-        var passive = false;
+  scrollListener() {
+    const el = this.scrollComponent;
+    const scrollEl = window;
+    const parentNode = this.getParentElement(el);
 
-        var testOptions = {
-          get passive() {
-            passive = true;
-          },
-        };
+    let offset;
+    if (this.props.useWindow) {
+      const doc = document.documentElement || document.body.parentNode || document.body;
+      const scrollTop = scrollEl.pageYOffset !== undefined ? scrollEl.pageYOffset : doc.scrollTop;
+      if (this.props.isReverse) {
+        offset = scrollTop;
+      } else {
+        offset = this.calculateOffset(el, scrollTop);
+      }
+    } else if (this.props.isReverse) {
+      if (parentNode.scrollTop >= 0) {
+        offset = parentNode.scrollTop;
+      } else {
+        // known issue with safari:
+        // scrollTop will be a negative value instead of positive, need to handle separately
+        // reference: https://bugzilla.mozilla.org/show_bug.cgi?id=1042151#c36
+        offset = parentNode.scrollHeight + parentNode.scrollTop - parentNode.clientHeight;
+      }
+    } else {
+      offset = el.scrollHeight - parentNode.scrollTop - parentNode.clientHeight;
+    }
 
-        try {
-          document.addEventListener('test', null, testOptions);
-          document.removeEventListener('test', null, testOptions);
-        } catch (e) {
-          // ignore
-        }
-        return passive;
-      },
-    },
-    {
-      key: 'eventListenerOptions',
-      value: function eventListenerOptions() {
-        var options = this.props.useCapture;
+    // Here we make sure the element is visible as well as checking the offset
+    if (offset < Number(this.props.threshold) && el && el.offsetParent !== null) {
+      this.detachScrollListener();
+      this.beforeScrollHeight = parentNode.scrollHeight;
+      this.beforeScrollTop = parentNode.scrollTop;
+      // Call loadMore after detachScrollListener to allow for non-async loadMore functions
+      if (typeof this.props.loadMore === 'function') {
+        this.props.loadMore((this.pageLoaded += 1));
+        this.loadMore = true;
+      }
+    }
+  }
 
-        if (this.isPassiveSupported()) {
-          options = {
-            useCapture: this.props.useCapture,
-            passive: true,
-          };
-        }
-        return options;
-      },
+  calculateOffset(el, scrollTop) {
+    if (!el) {
+      return 0;
+    }
 
-      // Set a defaut loader for all your `InfiniteScroll` components
-    },
-    {
-      key: 'setDefaultLoader',
-      value: function setDefaultLoader(loader) {
-        this.defaultLoader = loader;
-      },
-    },
-    {
-      key: 'detachMousewheelListener',
-      value: function detachMousewheelListener() {
-        var scrollEl = window;
-        if (this.props.useWindow === false) {
-          scrollEl = this.scrollComponent.parentNode;
-        }
+    return this.calculateTopPosition(el) + (el.offsetHeight - scrollTop - window.innerHeight);
+  }
 
-        scrollEl.removeEventListener(
-          'mousewheel',
-          this.mousewheelListener,
-          this.options ? this.options : this.props.useCapture
-        );
-      },
-    },
-    {
-      key: 'detachScrollListener',
-      value: function detachScrollListener() {
-        var scrollEl = window;
-        if (this.props.useWindow === false) {
-          scrollEl = this.getParentElement(this.scrollComponent);
-        }
+  calculateTopPosition(el) {
+    if (!el) {
+      return 0;
+    }
+    return el.offsetTop + this.calculateTopPosition(el.offsetParent);
+  }
 
-        scrollEl.removeEventListener(
-          'scroll',
-          this.scrollListener,
-          this.options ? this.options : this.props.useCapture
-        );
-        scrollEl.removeEventListener(
-          'resize',
-          this.scrollListener,
-          this.options ? this.options : this.props.useCapture
-        );
-      },
-    },
-    {
-      key: 'getParentElement',
-      value: function getParentElement(el) {
-        var scrollParent = this.props.getScrollParent && this.props.getScrollParent();
-        if (scrollParent != null) {
-          return scrollParent;
-        }
-        return el && el.parentNode;
-      },
-    },
-    {
-      key: 'filterProps',
-      value: function filterProps(props) {
-        return props;
-      },
-    },
-    {
-      key: 'attachScrollListener',
-      value: function attachScrollListener() {
-        var parentElement = this.getParentElement(this.scrollComponent);
+  render() {
+    const renderProps = this.filterProps(this.props);
+    const {
+      children,
+      element,
+      hasMore,
+      initialLoad,
+      isReverse,
+      loader,
+      loadMore,
+      pageStart,
+      ref,
+      threshold,
+      useCapture,
+      useWindow,
+      getScrollParent,
+      ...props
+    } = renderProps;
 
-        if (!this.props.hasMore || !parentElement) {
-          return;
-        }
+    props.ref = (node) => {
+      this.scrollComponent = node;
+      if (ref) {
+        ref(node);
+      }
+    };
 
-        var scrollEl = window;
-        if (this.props.useWindow === false) {
-          scrollEl = parentElement;
-        }
-
-        scrollEl.addEventListener(
-          'mousewheel',
-          this.mousewheelListener,
-          this.options ? this.options : this.props.useCapture
-        );
-        scrollEl.addEventListener('scroll', this.scrollListener, this.options ? this.options : this.props.useCapture);
-        scrollEl.addEventListener('resize', this.scrollListener, this.options ? this.options : this.props.useCapture);
-
-        if (this.props.initialLoad) {
-          this.scrollListener();
-        }
-      },
-    },
-    {
-      key: 'mousewheelListener',
-      value: function mousewheelListener(e) {
-        // Prevents Chrome hangups
-        // See: https://stackoverflow.com/questions/47524205/random-high-content-download-time-in-chrome/47684257#47684257
-        if (e.deltaY === 1 && !this.isPassiveSupported()) {
-          e.preventDefault();
-        }
-      },
-    },
-    {
-      key: 'scrollListener',
-      value: function scrollListener() {
-        var el = this.scrollComponent;
-        var scrollEl = window;
-        var parentNode = this.getParentElement(el);
-
-        var offset = void 0;
-        if (this.props.useWindow) {
-          var doc = document.documentElement || document.body.parentNode || document.body;
-          var scrollTop = scrollEl.pageYOffset !== undefined ? scrollEl.pageYOffset : doc.scrollTop;
-          if (this.props.isReverse) {
-            offset = scrollTop;
-          } else {
-            offset = this.calculateOffset(el, scrollTop);
-          }
-        } else if (this.props.isReverse) {
-          if (parentNode.scrollTop >= 0) {
-            offset = parentNode.scrollTop;
-          } else {
-            // known issue with safari:
-            // scrollTop will be a negative value instead of positive, need to handle separately
-            // reference: https://bugzilla.mozilla.org/show_bug.cgi?id=1042151#c36
-            offset = parentNode.scrollHeight + parentNode.scrollTop - parentNode.clientHeight;
-          }
-        } else {
-          offset = el.scrollHeight - parentNode.scrollTop - parentNode.clientHeight;
-        }
-
-        // Here we make sure the element is visible as well as checking the offset
-        if (offset < Number(this.props.threshold) && el && el.offsetParent !== null) {
-          this.detachScrollListener();
-          this.beforeScrollHeight = parentNode.scrollHeight;
-          this.beforeScrollTop = parentNode.scrollTop;
-          // Call loadMore after detachScrollListener to allow for non-async loadMore functions
-          if (typeof this.props.loadMore === 'function') {
-            this.props.loadMore((this.pageLoaded += 1));
-            this.loadMore = true;
-          }
-        }
-      },
-    },
-    {
-      key: 'calculateOffset',
-      value: function calculateOffset(el, scrollTop) {
-        if (!el) {
-          return 0;
-        }
-
-        return this.calculateTopPosition(el) + (el.offsetHeight - scrollTop - window.innerHeight);
-      },
-    },
-    {
-      key: 'calculateTopPosition',
-      value: function calculateTopPosition(el) {
-        if (!el) {
-          return 0;
-        }
-        return el.offsetTop + this.calculateTopPosition(el.offsetParent);
-      },
-    },
-    {
-      key: 'render',
-      value: function render() {
-        var _this2 = this;
-
-        var renderProps = this.filterProps(this.props);
-
-        var children = renderProps.children,
-          element = renderProps.element,
-          hasMore = renderProps.hasMore,
-          initialLoad = renderProps.initialLoad,
-          isReverse = renderProps.isReverse,
-          loader = renderProps.loader,
-          loadMore = renderProps.loadMore,
-          pageStart = renderProps.pageStart,
-          ref = renderProps.ref,
-          threshold = renderProps.threshold,
-          useCapture = renderProps.useCapture,
-          useWindow = renderProps.useWindow,
-          getScrollParent = renderProps.getScrollParent,
-          props = _objectWithoutProperties(renderProps, [
-            'children',
-            'element',
-            'hasMore',
-            'initialLoad',
-            'isReverse',
-            'loader',
-            'loadMore',
-            'pageStart',
-            'ref',
-            'threshold',
-            'useCapture',
-            'useWindow',
-            'getScrollParent',
-          ]);
-
-        props.ref = function (node) {
-          _this2.scrollComponent = node;
-          if (ref) {
-            ref(node);
-          }
-        };
-
-        var childrenArray = [children];
-        if (hasMore) {
-          if (loader) {
-            isReverse ? childrenArray.unshift(loader) : childrenArray.push(loader);
-          } else if (this.defaultLoader) {
-            isReverse ? childrenArray.unshift(this.defaultLoader) : childrenArray.push(this.defaultLoader);
-          }
-        }
-        return _react2.default.createElement(element, props, childrenArray);
-      },
-    },
-  ]);
-
-  return InfiniteScroll;
-})(_react.Component);
-
-InfiniteScroll.propTypes = {
-  children: _propTypes2.default.node.isRequired,
-  element: _propTypes2.default.node,
-  hasMore: _propTypes2.default.bool,
-  initialLoad: _propTypes2.default.bool,
-  isReverse: _propTypes2.default.bool,
-  loader: _propTypes2.default.node,
-  loadMore: _propTypes2.default.func.isRequired,
-  pageStart: _propTypes2.default.number,
-  ref: _propTypes2.default.func,
-  getScrollParent: _propTypes2.default.func,
-  threshold: _propTypes2.default.number,
-  useCapture: _propTypes2.default.bool,
-  useWindow: _propTypes2.default.bool,
-};
-InfiniteScroll.defaultProps = {
-  element: 'div',
-  hasMore: false,
-  initialLoad: true,
-  pageStart: 0,
-  ref: null,
-  threshold: 250,
-  useWindow: true,
-  isReverse: false,
-  useCapture: false,
-  loader: null,
-  getScrollParent: null,
-};
-exports.default = InfiniteScroll;
-module.exports = exports['default'];
+    const childrenArray = [children];
+    if (hasMore) {
+      if (loader) {
+        isReverse ? childrenArray.unshift(loader) : childrenArray.push(loader);
+      } else if (this.defaultLoader) {
+        isReverse ? childrenArray.unshift(this.defaultLoader) : childrenArray.push(this.defaultLoader);
+      }
+    }
+    return React.createElement(element, props, childrenArray);
+  }
+}


### PR DESCRIPTION
Utilised `react-device-detect` to determine whether the device is mobile
Utilised `react-stay-scrolled` to (1) accurately scroll to the bottom of the messages and (2) make sure that the scroll position does not change when adding new chat messages. (needed because Safari does not support `overflow-anchor` property)

- Add scroll to bottom of chat dialog when mounted
- Uninstall `react-infinite-loader` (not being maintained actively), and overwrite it to fix the issue and use custom infinite loader. 
- Allow mobile to press `return/new line` button (which has the same keyCode as the enter key in desktops) to add new line instead of sending
- Prevent scroll position from changing when adding new chat messages.