### PR TITLE
Make height of chat page exactly fit into mobile

### DIFF
--- a/src/components/chat/modules/ChatDialog.js
+++ b/src/components/chat/modules/ChatDialog.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import Measure from 'react-measure';
 import { Stack, ButtonLink } from '@kiwicom/orbit-components/lib';
 import ChatDialogUserRow from './ChatDialogUserRow';
@@ -42,7 +42,6 @@ const ChatDialogContent = ({
   // default as 68 px which is single line text area, modified when there
   // is more than one line in the text area in input row
   const [inputRowHeight, setInputRowHeight] = useState(68);
-  const chatDialogEndRef = useRef(null);
 
   let chatPostTitle, oppositeUser, chatPostType, chatPostId, postOwnerId, postEnquirerId, postStatus;
   const isCreatingNewChatForAPost = postId !== null && isNewChat;
@@ -66,10 +65,6 @@ const ChatDialogContent = ({
     postEnquirerId = chatPostType === donations ? chat.npo.id : chat.donor.id;
     postStatus = chat.post.status;
   }
-
-  useEffect(() => {
-    chatDialogEndRef.current.scrollIntoView();
-  }, []);
 
   return (
     <>
@@ -123,7 +118,6 @@ const ChatDialogContent = ({
           />
         )}
       </Measure>
-      <div ref={chatDialogEndRef} />
     </>
   );
 };

--- a/src/components/chat/modules/ChatDialogMessages.js
+++ b/src/components/chat/modules/ChatDialogMessages.js
@@ -10,6 +10,7 @@ import { wishes } from '../../../../utils/constants/postType';
 import { CHAT_MESSAGES_BATCH_SIZE } from '../../../../utils/api/constants';
 import { LeftMessageSection, RightMessageSection } from './ChatMessageSection';
 import useStayScrolled from 'react-stay-scrolled';
+import useWindowDimensions from '../../../../utils/hooks/useWindowDimensions';
 
 /**
  * To be changed if any of the heights change, the extra "+1 or +2" for the top/bottom borders
@@ -23,15 +24,15 @@ const desktopHeights = {
 
 const mobileHeights = {
   chatDialogBackButton: 44,
-  chatDialogUserRow: 104 + 1,
+  chatDialogUserRow: 108 + 1,
   chatDialogSeePostRow: 96 + 1,
   chatDialogMessagesPadding: 32 + 2,
 };
 
 const MessageContainer = styled.div`
   width: 100%;
-  min-height: calc(100vh - ${({ offsetHeight }) => offsetHeight}px);
-  max-height: calc(100vh - ${({ offsetHeight }) => offsetHeight}px);
+  min-height: ${({ offsetHeight, viewportHeight }) => viewportHeight - offsetHeight}px;
+  max-height: ${({ offsetHeight, viewportHeight }) => viewportHeight - offsetHeight}px;
   position: relative;
   overflow-y: scroll;
   overflow-x: hidden;
@@ -51,6 +52,7 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
   const { isTablet } = useMediaQuery();
   const scrollerRef = useRef(null);
   const { stayScrolled, scrollBottom } = useStayScrolled(scrollerRef);
+  const { height: viewportHeight } = useWindowDimensions();
 
   useEffect(() => {
     // reset values every time selectedChatId changes
@@ -139,7 +141,7 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
   if (isNewChat && !selectedChatId && postType === wishes) {
     return (
       <CardSection>
-        <MessageContainer offsetHeight={offsetHeight} ref={scrollerRef}>
+        <MessageContainer offsetHeight={offsetHeight} ref={scrollerRef} viewportHeight={viewportHeight}>
           <NewChatTips postType={postType} />
         </MessageContainer>
       </CardSection>
@@ -148,7 +150,7 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
 
   return (
     <CardSection>
-      <MessageContainer offsetHeight={offsetHeight} ref={scrollerRef}>
+      <MessageContainer offsetHeight={offsetHeight} ref={scrollerRef} viewportHeight={viewportHeight}>
         <InfiniteScroll
           loadMore={handleOnSeeMore}
           hasMore={shouldSeeMore}

--- a/src/components/chat/pages/ChatPage.js
+++ b/src/components/chat/pages/ChatPage.js
@@ -7,6 +7,7 @@ import Error from 'next/error';
 import styled from 'styled-components';
 import { EMAIL_BAR_HEIGHT, NAVBAR_HEIGHT } from '../../../../utils/constants/navbar';
 import useMediaQuery from '@kiwicom/orbit-components/lib/hooks/useMediaQuery';
+import useWindowDimensions from '../../../../utils/hooks/useWindowDimensions';
 
 const NoChatsContainer = styled.div`
   margin: 0 auto;
@@ -151,6 +152,7 @@ const ChatPage = ({ user, chatId, postId, postType, isViewingChatsForMyPost }) =
   }, []);
 
   const { isTablet } = useMediaQuery();
+  const { height } = useWindowDimensions();
   const navBarConstant = isTablet ? 'DESKTOP' : 'MOBILE';
   const navBarOffsetHeight = user
     ? user.user.emailVerified
@@ -159,7 +161,7 @@ const ChatPage = ({ user, chatId, postId, postType, isViewingChatsForMyPost }) =
     : NAVBAR_HEIGHT[navBarConstant];
 
   const gridContainerStyle = {
-    height: `calc(100vh - ${navBarOffsetHeight}px)`,
+    height: `${height - navBarOffsetHeight}px`,
     width: '100vw',
   };
 

--- a/utils/hooks/useWindowDimensions.js
+++ b/utils/hooks/useWindowDimensions.js
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+
+export default function useWindowDimensions() {
+  const hasWindow = typeof window !== 'undefined';
+
+  function getWindowDimensions() {
+    const width = hasWindow ? window.innerWidth : null;
+    const height = hasWindow ? window.innerHeight : null;
+    return {
+      width,
+      height,
+    };
+  }
+
+  const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions());
+
+  useEffect(() => {
+    if (hasWindow) {
+      function handleResize() {
+        setWindowDimensions(getWindowDimensions());
+      }
+
+      window.addEventListener('resize', handleResize);
+      return () => window.removeEventListener('resize', handleResize);
+    }
+  }, [hasWindow]);
+
+  return windowDimensions;
+}

--- a/utils/hooks/useWindowDimensions.js
+++ b/utils/hooks/useWindowDimensions.js
@@ -1,16 +1,16 @@
 import { useState, useEffect } from 'react';
 
-export default function useWindowDimensions() {
+const useWindowDimensions = () => {
   const hasWindow = typeof window !== 'undefined';
 
-  function getWindowDimensions() {
+  const getWindowDimensions = () => {
     const width = hasWindow ? window.innerWidth : null;
     const height = hasWindow ? window.innerHeight : null;
     return {
       width,
       height,
     };
-  }
+  };
 
   const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions());
 
@@ -26,4 +26,6 @@ export default function useWindowDimensions() {
   }, [hasWindow]);
 
   return windowDimensions;
-}
+};
+
+export default useWindowDimensions;


### PR DESCRIPTION
Currently, `100vh` is being used for the height of the viewport. However, `100vh` includes the height of the browser's bottom  panel. Hence, within the chat page, scrolling is needed to see the full page.

Let's create a hook that uses `window.innerHeight` to calculate the height of the viewport. `window.innerHeight` does not include the height of the browser's bottom panel.