### PR TITLE
Fix white space in safari ios chat

### DIFF
--- a/src/components/chat/modules/ChatMessageSection.js
+++ b/src/components/chat/modules/ChatMessageSection.js
@@ -16,6 +16,11 @@ const RightColumnStackContainer = styled.div`
 `;
 
 const RightMessageSectionContainer = styled.div`
+  /* 
+    Needed to prevent negative z-index for ios safari: 
+    https://css-tricks.com/forums/topic/safari-for-ios-z-index-ordering-bug-while-scrolling-a-page-with-a-fixed-element/  
+  */
+  -webkit-transform: translate3d(0, 0, 0);
   width: fit-content;
   max-width: 90%;
   ${media.tablet(css`
@@ -28,6 +33,11 @@ const LeftColumnStackContainer = styled.div`
 `;
 
 const LeftMessageSectionContainer = styled.div`
+  /* 
+    Needed to prevent negative z-index for ios safari: 
+    https://css-tricks.com/forums/topic/safari-for-ios-z-index-ordering-bug-while-scrolling-a-page-with-a-fixed-element/  
+  */
+  -webkit-transform: translate3d(0, 0, 0);
   width: fit-content;
   max-width: 90%;
   ${media.tablet(css`


### PR DESCRIPTION
Fixes the issue where in safari ios, not able to view the chat messages during initial load, but able to view the messages after a slight scroll.

Solution obtained from: https://css-tricks.com/forums/topic/safari-for-ios-z-index-ordering-bug-while-scrolling-a-page-with-a-fixed-element/