### PR TITLE
Remove react-stay-scrolled package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13269,15 +13269,6 @@
         "workbox-webpack-plugin": "4.3.1"
       }
     },
-    "react-stay-scrolled": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/react-stay-scrolled/-/react-stay-scrolled-7.1.0.tgz",
-      "integrity": "sha512-/rIsHqTnSwMs6crYL+AoFfxBIH5iUNE+EqbOF+cSNyGoTvweQCKWaOqey8wKwDysld+X4HLPqQnobSAzKoAUgA==",
-      "requires": {
-        "memoize-one": "^5.1.1",
-        "tiny-invariant": "^1.1.0"
-      }
-    },
     "react-textarea-autosize": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "react-redux": "^7.2.0",
     "react-responsive-carousel": "^3.2.7",
     "react-scripts": "3.4.0",
-    "react-stay-scrolled": "^7.1.0",
     "react-textarea-autosize": "^8.2.0",
     "react-tiny-popover": "^5.1.0",
     "react-toastify": "^6.0.5",

--- a/src/components/chat/modules/ChatDialogMessages.js
+++ b/src/components/chat/modules/ChatDialogMessages.js
@@ -138,7 +138,7 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
   if (isNewChat && !selectedChatId && postType === wishes) {
     return (
       <CardSection>
-        <MessageContainer offsetHeight={offsetHeight} ref={scrollerRef} viewportHeight={viewportHeight}>
+        <MessageContainer offsetHeight={offsetHeight} viewportHeight={viewportHeight}>
           <NewChatTips postType={postType} />
         </MessageContainer>
       </CardSection>

--- a/src/components/chat/modules/ChatDialogMessages.js
+++ b/src/components/chat/modules/ChatDialogMessages.js
@@ -9,7 +9,6 @@ import InfiniteScroll from '../../scroller/InfiniteScroller';
 import { wishes } from '../../../../utils/constants/postType';
 import { CHAT_MESSAGES_BATCH_SIZE } from '../../../../utils/api/constants';
 import { LeftMessageSection, RightMessageSection } from './ChatMessageSection';
-import useStayScrolled from 'react-stay-scrolled';
 
 /**
  * To be changed if any of the heights change, the extra "+1 or +2" for the top/bottom borders
@@ -49,8 +48,7 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
   // to have messages initially
   const [shouldSeeMore, setShouldSeeMore] = useState(!isNewChat);
   const { isTablet } = useMediaQuery();
-  const scrollerRef = useRef(null);
-  const { stayScrolled, scrollBottom } = useStayScrolled(scrollerRef);
+  const bottomOfScrollerRef = useRef(null);
 
   useEffect(() => {
     // reset values every time selectedChatId changes
@@ -75,7 +73,7 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
 
   const scrollToBottomIfSentByLoggedInUser = (chatMessage) => {
     if (chatMessage.sender.id === loggedInUser.user.userId) {
-      scrollBottom();
+      bottomOfScrollerRef.current.scrollIntoView();
     }
   };
 
@@ -120,7 +118,6 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
         // loaded all chat messages
         setShouldSeeMore(false);
       }
-      stayScrolled(); // so that adding new messages won't shift the scroll position
     });
   };
 
@@ -148,7 +145,7 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
 
   return (
     <CardSection>
-      <MessageContainer offsetHeight={offsetHeight} ref={scrollerRef}>
+      <MessageContainer offsetHeight={offsetHeight}>
         <InfiniteScroll
           loadMore={handleOnSeeMore}
           hasMore={shouldSeeMore}
@@ -181,6 +178,7 @@ const ChatDialogMessages = ({ postType, loggedInUser, selectedChatId, isNewChat,
                 );
               })}
           </Stack>
+          <div ref={bottomOfScrollerRef} />
         </InfiniteScroll>
       </MessageContainer>
     </CardSection>


### PR DESCRIPTION
Removing react-stay-scrolled package as it does not achieve what I initially thought it would achieve, i.e. maintain the scroll position when new items added within the scroller component.

Note: the `stayScrolled()` method **does not** maintain the scroll position, which is the main reason i wanted to use this package initially.