### PR TITLE
Add word break to all cards and post details

### DIFF
--- a/src/components/card/BumpableWishCard.js
+++ b/src/components/card/BumpableWishCard.js
@@ -49,6 +49,7 @@ const ThreeLineTextContainer = styled.div`
   font-size: 14px;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
+  word-break: break-word;
 `;
 
 const LineTextContainer = styled.div`
@@ -60,6 +61,7 @@ const LineTextContainer = styled.div`
   font-size: 14px;
   -webkit-line-clamp: ${(props) => (props.isTablet ? '7' : '8')};
   -webkit-box-orient: vertical;
+  word-break: break-word;
 `;
 
 const CardDescriptionContainer = styled.div`

--- a/src/components/card/DonationCard.js
+++ b/src/components/card/DonationCard.js
@@ -34,6 +34,18 @@ const CardHeaderContainer = styled.div`
   display: flex;
 `;
 
+const OneLineTextContainer = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  line-height: 1.5em;
+  max-height: 1.5em;
+  font-size: 14px;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  word-break: break-word;
+`;
+
 const TwoLineTextContainer = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
@@ -43,6 +55,7 @@ const TwoLineTextContainer = styled.div`
   font-size: 14px;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+  word-break: break-word;
 `;
 
 // note that card image container takes 3/6 fractions of the entire height of card
@@ -88,9 +101,11 @@ const ClickableDiv = styled.a`
 const CardDescription = ({ title, description }) => {
   return (
     <Stack direction="column" spacing="tight">
-      <Text size="normal" weight="bold">
-        {title}
-      </Text>
+      <OneLineTextContainer>
+        <Text size="normal" weight="bold">
+          {title}
+        </Text>
+      </OneLineTextContainer>
       <TwoLineTextContainer>{description}</TwoLineTextContainer>
     </Stack>
   );

--- a/src/components/card/GroupWishCard.js
+++ b/src/components/card/GroupWishCard.js
@@ -14,6 +14,18 @@ const ClickableDiv = styled.a`
   z-index: 1;
 `;
 
+const OneLineTextContainer = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  line-height: 1.5em;
+  max-height: 1.5em;
+  font-size: 14px;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  word-break: break-word;
+`;
+
 const TwoLineTextContainer = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
@@ -24,6 +36,7 @@ const TwoLineTextContainer = styled.div`
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   text-align: start;
+  word-break: break-word;
 `;
 
 const CardContentContainer = styled.div`
@@ -34,9 +47,11 @@ const CardContentContainer = styled.div`
 const CardDescription = ({ title, description }) => {
   return (
     <Stack direction="column" spacing="tight">
-      <Text size="normal" weight="bold">
-        {title}
-      </Text>
+      <OneLineTextContainer>
+        <Text size="normal" weight="bold">
+          {title}
+        </Text>
+      </OneLineTextContainer>
       <TwoLineTextContainer>{description}</TwoLineTextContainer>
     </Stack>
   );

--- a/src/components/card/WishCard.js
+++ b/src/components/card/WishCard.js
@@ -40,6 +40,7 @@ const ThreeLineTextContainer = styled.div`
   font-size: 14px;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
+  word-break: break-word;
 `;
 
 const EightLineTextContainer = styled.div`
@@ -51,6 +52,7 @@ const EightLineTextContainer = styled.div`
   font-size: 14px;
   -webkit-line-clamp: 8;
   -webkit-box-orient: vertical;
+  word-break: break-word;
 `;
 
 const CardDescriptionContainer = styled.div`

--- a/src/components/donationDetail/modules/DonationInformation.js
+++ b/src/components/donationDetail/modules/DonationInformation.js
@@ -33,6 +33,14 @@ const BadgeWrapper = styled.div`
   margin-bottom: 8px !important;
 `;
 
+const TitleTextContainer = styled.div`
+  word-break: break-word;
+`;
+
+const DescriptionTextContainer = styled.div`
+  word-break: break-word;
+`;
+
 const DonationInformation = ({
   loginUserId,
   loginUserType,
@@ -104,8 +112,12 @@ const DonationInformation = ({
       <DonationDescriptionContainer>
         <Stack direction="column" spacing="loose">
           <Stack>
-            <Heading type="title2">{title}</Heading>
-            <Text>{description}</Text>
+            <TitleTextContainer>
+              <Heading type="title2">{title}</Heading>
+            </TitleTextContainer>
+            <DescriptionTextContainer>
+              <Text>{description}</Text>
+            </DescriptionTextContainer>
           </Stack>
           <Stack direction="row" wrap="true">
             <CategoryTags />

--- a/src/components/wishDetail/modules/WishInformation.js
+++ b/src/components/wishDetail/modules/WishInformation.js
@@ -16,6 +16,14 @@ const BadgeWrapper = styled.div`
   margin-bottom: 8px !important;
 `;
 
+const TitleTextContainer = styled.div`
+  word-break: break-word;
+`;
+
+const DescriptionTextContainer = styled.div`
+  word-break: break-word;
+`;
+
 const WishInformation = ({
   loginUserId,
   loginUserType,
@@ -44,8 +52,12 @@ const WishInformation = ({
       <WishInformationBodyContainer>
         <Stack direction="column" spacing="loose">
           <Stack>
-            <Heading type="title2">{title}</Heading>
-            <Text>{description}</Text>
+            <TitleTextContainer>
+              <Heading type="title2">{title}</Heading>
+            </TitleTextContainer>
+            <DescriptionTextContainer>
+              <Text>{description}</Text>
+            </DescriptionTextContainer>
           </Stack>
           <Stack direction="row" wrap="true">
             <CategoryTags />


### PR DESCRIPTION
Fixes
- donation  and wish details:

Before
<img width="300" alt="Screen Shot 2020-07-28 at 9 03 44 PM" src="https://user-images.githubusercontent.com/32864116/88669754-e0400880-d116-11ea-89f7-e89288b6710f.png">

After
<img width="300" alt="Screen Shot 2020-07-28 at 9 03 16 PM" src="https://user-images.githubusercontent.com/32864116/88669745-dc13eb00-d116-11ea-98c7-eeddfe82b25f.png">

 - donation cards:

Before
<img width="300" alt="Screen Shot 2020-07-28 at 9 04 19 PM" src="https://user-images.githubusercontent.com/32864116/88669891-0a91c600-d117-11ea-8342-320ffbbe5892.png">

After
<img width="300" alt="Screen Shot 2020-07-28 at 9 04 00 PM" src="https://user-images.githubusercontent.com/32864116/88669876-05cd1200-d117-11ea-80e8-4ce3f059f211.png">

- bumpable wish card and wish cards:

Before
<img width="300" alt="Screen Shot 2020-07-28 at 9 06 27 PM" src="https://user-images.githubusercontent.com/32864116/88670022-29905800-d117-11ea-8beb-ac0dc76bd27f.png">


After
<img width="300" alt="Screen Shot 2020-07-28 at 9 06 44 PM" src="https://user-images.githubusercontent.com/32864116/88670029-2bf2b200-d117-11ea-8e0e-9ef18c7a2d1b.png">

- group wish cards

Before
<img width="300" alt="Screen Shot 2020-07-28 at 9 07 53 PM" src="https://user-images.githubusercontent.com/32864116/88670062-34e38380-d117-11ea-8cbb-694286c96bac.png">

After
<img width="300" alt="Screen Shot 2020-07-28 at 9 07 26 PM" src="https://user-images.githubusercontent.com/32864116/88670142-4b89da80-d117-11ea-8c4c-e43e5c84e454.png">
