### PR TITLE
ChatId: Add userId to subscribe and unsubscribe chat messages

### DIFF
--- a/pages/chat/index.js
+++ b/pages/chat/index.js
@@ -6,6 +6,7 @@ import api from '../../utils/api';
 import Error from 'next/error';
 import ChatPage from '../../src/components/chat/pages/ChatPage';
 import Header from '../../src/components/header';
+import { donations, wishes } from '../../utils/constants/postType';
 
 const TopNavigationBar = dynamic(() => import('../../src/components/navbar/modules/TopNavigationBar'), {
   ssr: false,
@@ -21,6 +22,15 @@ const TopNavigationBar = dynamic(() => import('../../src/components/navbar/modul
 export async function getServerSideProps({ params, req, res, query }) {
   const user = await isAuthenticated(req, res);
   if (!user) {
+    return {
+      props: {
+        hasError: true,
+      },
+    };
+  }
+
+  if (!user.user.emailVerified) {
+    // user is not email verified
     return {
       props: {
         hasError: true,
@@ -48,6 +58,18 @@ export async function getServerSideProps({ params, req, res, query }) {
     }
     const post = rawPost.data();
     isViewingChatsForMyPost = post.user.userId === user.user.userId;
+
+    if (
+      !isViewingChatsForMyPost &&
+      ((user.user.donor && postType === donations) || (user.user.npo && postType === wishes))
+    ) {
+      // creating a new chat, but is donor -> donation, npo -> wishes
+      return {
+        props: {
+          hasError: true,
+        },
+      };
+    }
   }
 
   return {
@@ -61,7 +83,7 @@ export async function getServerSideProps({ params, req, res, query }) {
   };
 }
 
-const ViewOwnChats = ({ user, postId, chatId, isViewingChatsForMyPost, postType, hasError }) => {
+const ViewChats = ({ user, postId, chatId, isViewingChatsForMyPost, postType, hasError }) => {
   if (hasError) {
     return <Error />;
   }
@@ -81,4 +103,4 @@ const ViewOwnChats = ({ user, postId, chatId, isViewingChatsForMyPost, postType,
   );
 };
 
-export default ViewOwnChats;
+export default ViewChats;

--- a/utils/api/chats.js
+++ b/utils/api/chats.js
@@ -10,7 +10,6 @@ import { ON, OFF } from '../constants/chatStatus';
 import { ADDED, MODIFIED } from '../constants/chatSubscriptionChange';
 import { uploadImage } from './common/images';
 import { getCurrentUser } from './common/user';
-import { isValidUserType } from '../constants/userType';
 import ChatError from './error/chatError';
 
 const chatsCollection = db.collection('chats');


### PR DESCRIPTION
With the current approach, unsubscribing to chat messages gets the current user id to update some of the fields in chats. As highlighted by @jamessspanggg, when a user logged out on the chat page, the API will throw an error as current user will be null. 

To solve this issue, we will need to add `userId` to unsubscribe chat messages, so that we do not need to fetch the user. To ensure consistency in the API, I have to add `userId` to subscribing of chat messages as well. 