### PR TITLE
Add animation when revealing post details

### DIFF
--- a/src/components/chat/modules/ChatDialog.js
+++ b/src/components/chat/modules/ChatDialog.js
@@ -7,11 +7,12 @@ import ChatDialogMessages from './ChatDialogMessages';
 import ChatDialogInputRow from './ChatDialogInputRow';
 import BlackText from '../../text/BlackText';
 import api from '../../../../utils/api';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import ChevronLeft from '@kiwicom/orbit-components/lib/icons/ChevronLeft';
 import ChevronDown from '@kiwicom/orbit-components/lib/icons/ChevronDown';
 import ChevronUp from '@kiwicom/orbit-components/lib/icons/ChevronUp';
 import useMediaQuery from '@kiwicom/orbit-components/lib/hooks/useMediaQuery';
+import media from '@kiwicom/orbit-components/lib/utils/mediaQuery';
 import { donations } from '../../../../utils/constants/postType';
 
 const ChatDialogContainer = styled.div`
@@ -30,6 +31,31 @@ const MessageContainer = styled.div`
 const ButtonsWrapper = styled.div`
   margin: 0 auto;
   width: 90%;
+`;
+
+const ChatDialogPostDetails = styled.div`
+  @keyframes slideInFromTop {
+    0% {
+      transform: translateY(-50%);
+      opacity: 0%;
+    }
+
+    50% {
+      opacity: 0%;
+    }
+
+    100% {
+      transform: translateY(0);
+      opacity: 100%;
+    }
+  }
+  ${media.tablet(css`
+    animation-duration: 0s;
+  `)}
+  animation-name: slideInFromTop;
+  animation-duration: 0.5s;
+  width: 100%;
+  display: ${({ isShow }) => (isShow ? 'unset' : 'none')};
 `;
 
 const ChatDialogContent = ({
@@ -100,26 +126,24 @@ const ChatDialogContent = ({
             </Stack>
           </ButtonsWrapper>
         )}
-        {isShowPostDetails && (
-          <>
-            <ChatDialogUserRow
-              postId={chatPostId}
-              postType={chatPostType}
-              postStatus={postStatus}
-              rating={5} // apparently rating is not within the user in donations/wishes, default val for now
-              loggedInUser={loggedInUser}
-              oppositeUser={oppositeUser}
-              postOwnerId={postOwnerId}
-              postEnquirerId={postEnquirerId}
-              setHasError={setHasError}
-              selectedChatId={selectedChatId}
-              setSelectedChatId={setSelectedChatId}
-              isNewChat={isNewChat}
-              setIsNewChat={setIsNewChat}
-            />
-            <ChatDialogViewPostRow postType={chatPostType} postId={chatPostId} postTitle={chatPostTitle} />
-          </>
-        )}
+        <ChatDialogPostDetails isShow={isShowPostDetails}>
+          <ChatDialogUserRow
+            postId={chatPostId}
+            postType={chatPostType}
+            postStatus={postStatus}
+            rating={5} // apparently rating is not within the user in donations/wishes, default val for now
+            loggedInUser={loggedInUser}
+            oppositeUser={oppositeUser}
+            postOwnerId={postOwnerId}
+            postEnquirerId={postEnquirerId}
+            setHasError={setHasError}
+            selectedChatId={selectedChatId}
+            setSelectedChatId={setSelectedChatId}
+            isNewChat={isNewChat}
+            setIsNewChat={setIsNewChat}
+          />
+          <ChatDialogViewPostRow postType={chatPostType} postId={chatPostId} postTitle={chatPostTitle} />
+        </ChatDialogPostDetails>
         <ChatDialogMessages
           postType={chatPostType}
           loggedInUser={loggedInUser}

--- a/src/components/chat/modules/ChatDialog.js
+++ b/src/components/chat/modules/ChatDialog.js
@@ -7,13 +7,13 @@ import ChatDialogMessages from './ChatDialogMessages';
 import ChatDialogInputRow from './ChatDialogInputRow';
 import BlackText from '../../text/BlackText';
 import api from '../../../../utils/api';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import ChevronLeft from '@kiwicom/orbit-components/lib/icons/ChevronLeft';
 import ChevronDown from '@kiwicom/orbit-components/lib/icons/ChevronDown';
 import ChevronUp from '@kiwicom/orbit-components/lib/icons/ChevronUp';
 import useMediaQuery from '@kiwicom/orbit-components/lib/hooks/useMediaQuery';
-import media from '@kiwicom/orbit-components/lib/utils/mediaQuery';
 import { donations } from '../../../../utils/constants/postType';
+import useDelayUnmount from '../../../../utils/hooks/useDelayedUnmount';
 
 const ChatDialogContainer = styled.div`
   width: 100%;
@@ -49,13 +49,23 @@ const ChatDialogPostDetails = styled.div`
       opacity: 100%;
     }
   }
-  ${media.tablet(css`
-    animation-duration: 0s;
-  `)}
-  animation-name: slideInFromTop;
-  animation-duration: 0.5s;
+
+  @keyframes slideOutFromBottom {
+    0% {
+      transform: translateY(0);
+      opacity: 100%;
+    }
+
+    50% {
+      opacity: 0%;
+    }
+
+    100% {
+      transform: translateY(-50%);
+      opacity: 0%;
+    }
+  }
   width: 100%;
-  display: ${({ isShow }) => (isShow ? 'unset' : 'none')};
 `;
 
 const ChatDialogContent = ({
@@ -100,6 +110,11 @@ const ChatDialogContent = ({
     postStatus = chat.post.status;
   }
 
+  // used to determine when to mount/unmount the post details with animations
+  const shouldMountPostDetails = useDelayUnmount(isShowPostDetails, 200);
+  const mountedAnimationStyle = { animation: 'slideInFromTop 0.5s' };
+  const unmountedAnimationStyle = { animation: 'slideOutFromBottom 0.5s' };
+
   return (
     <>
       <Stack direction="column" spacing="none">
@@ -126,24 +141,26 @@ const ChatDialogContent = ({
             </Stack>
           </ButtonsWrapper>
         )}
-        <ChatDialogPostDetails isShow={isShowPostDetails}>
-          <ChatDialogUserRow
-            postId={chatPostId}
-            postType={chatPostType}
-            postStatus={postStatus}
-            rating={5} // apparently rating is not within the user in donations/wishes, default val for now
-            loggedInUser={loggedInUser}
-            oppositeUser={oppositeUser}
-            postOwnerId={postOwnerId}
-            postEnquirerId={postEnquirerId}
-            setHasError={setHasError}
-            selectedChatId={selectedChatId}
-            setSelectedChatId={setSelectedChatId}
-            isNewChat={isNewChat}
-            setIsNewChat={setIsNewChat}
-          />
-          <ChatDialogViewPostRow postType={chatPostType} postId={chatPostId} postTitle={chatPostTitle} />
-        </ChatDialogPostDetails>
+        {shouldMountPostDetails && (
+          <ChatDialogPostDetails style={isShowPostDetails ? mountedAnimationStyle : unmountedAnimationStyle}>
+            <ChatDialogUserRow
+              postId={chatPostId}
+              postType={chatPostType}
+              postStatus={postStatus}
+              rating={5} // apparently rating is not within the user in donations/wishes, default val for now
+              loggedInUser={loggedInUser}
+              oppositeUser={oppositeUser}
+              postOwnerId={postOwnerId}
+              postEnquirerId={postEnquirerId}
+              setHasError={setHasError}
+              selectedChatId={selectedChatId}
+              setSelectedChatId={setSelectedChatId}
+              isNewChat={isNewChat}
+              setIsNewChat={setIsNewChat}
+            />
+            <ChatDialogViewPostRow postType={chatPostType} postId={chatPostId} postTitle={chatPostTitle} />
+          </ChatDialogPostDetails>
+        )}
         <ChatDialogMessages
           postType={chatPostType}
           loggedInUser={loggedInUser}
@@ -151,7 +168,7 @@ const ChatDialogContent = ({
           isNewChat={isNewChat}
           navBarHeight={navBarHeight}
           inputRowHeight={inputRowHeight}
-          isShowPostDetails={isShowPostDetails}
+          shouldMountPostDetails={shouldMountPostDetails}
         />
       </Stack>
       <Measure bounds onResize={(contentRect) => setInputRowHeight(contentRect.bounds.height)}>

--- a/src/components/chat/modules/ChatDialogMessages.js
+++ b/src/components/chat/modules/ChatDialogMessages.js
@@ -17,14 +17,14 @@ import useWindowDimensions from '../../../../utils/hooks/useWindowDimensions';
 const desktopHeights = {
   chatDialogBackButton: 0, // 0 as it does not exist in desktop
   chatDialogUserRow: 88 + 1,
-  chatDialogSeePostRow: 113 + 1,
+  chatDialogSeePostRow: 113 + 2,
   chatDialogMessagesPadding: 48 + 2,
 };
 
 const mobileHeights = {
   chatDialogBackButton: 44,
   chatDialogUserRow: 108 + 1,
-  chatDialogSeePostRow: 96 + 1,
+  chatDialogSeePostRow: 96 + 2,
   chatDialogMessagesPadding: 32 + 2,
 };
 
@@ -50,7 +50,7 @@ const ChatDialogMessages = ({
   isNewChat,
   navBarHeight,
   inputRowHeight,
-  isShowPostDetails,
+  shouldMountPostDetails,
 }) => {
   const [chatMessageDocs, setChatMessageDocs] = useState([]);
   // only consider loading more when it's not a new chat, since it's impossible to have a new chat
@@ -139,7 +139,7 @@ const ChatDialogMessages = ({
 
   let sumOfOtherComponentHeights = chatDialogBackButton + chatDialogMessagesPadding + inputRowHeight;
 
-  if (isShowPostDetails) {
+  if (shouldMountPostDetails) {
     // only add the heights of see post row and user row if it is going to be shown
     sumOfOtherComponentHeights += chatDialogSeePostRow + chatDialogUserRow;
   }

--- a/utils/hooks/useDelayedUnmount.js
+++ b/utils/hooks/useDelayedUnmount.js
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Credits to @deckele in stackoverflow:
+ * https://codesandbox.io/s/lpn3261j99?file=/src/index.tsx:1072-1121
+ *
+ * Creates a delay before unmounting so that the animation gets to run before the component
+ * gets unmounted. Returns shouldRender that determines whether to unmount component.
+ */
+const useDelayUnmount = (isShow, delayTime) => {
+  const [shouldRender, setShouldRender] = useState(false);
+
+  useEffect(() => {
+    let timeoutId;
+    if (isShow && !shouldRender) {
+      setShouldRender(true);
+    } else if (!isShow && shouldRender) {
+      timeoutId = setTimeout(() => setShouldRender(false), delayTime);
+    }
+    return () => clearTimeout(timeoutId);
+  }, [isShow, delayTime, shouldRender]);
+  return shouldRender;
+};
+
+export default useDelayUnmount;


### PR DESCRIPTION
Created a new hook `useDelayAmount` that delays an amount of time before unmounting a particular component.

This hook is used to unmount the post details after the animations have finished.

Animation Demo:
![animation](https://user-images.githubusercontent.com/32864116/88796927-180d8580-d1d5-11ea-8d3c-25ef45ef4bb0.gif)
