### PR TITLE
Fix chat already exists error after sending first text msg

### DIFF
--- a/src/components/chat/modules/ChatDialogInputRow.js
+++ b/src/components/chat/modules/ChatDialogInputRow.js
@@ -82,6 +82,7 @@ const ChatDialogInputRow = ({ selectedChatId, setSelectedChatId, isNewChat, setI
     const method = postType === donations ? 'sendInitialTextMessageForDonation' : 'sendInitialTextMessageForWish';
     const [rawChat, rawFirstMessage] = await api.chats[method](postId, message);
     const chatId = rawChat.data().chatId;
+    setIsNewChat(false);
     setSelectedChatId(chatId);
     router.push(`/chat`, `/chat?chatId=${chatId}`, { shallow: true });
   };


### PR DESCRIPTION
Fixes the issue where after sending the first text message, sending further messages shows a `chat already exists` error.

Fixes google docs issue 6