### PR TITLE
Fix issues in register donor page

### DIFF
--- a/src/components/register/modules/RegisterDonor.js
+++ b/src/components/register/modules/RegisterDonor.js
@@ -140,7 +140,7 @@ const RegisterDonor = () => {
         onClick={handleGoogleRegister}
         loading={googleLoading}
       >
-        Sign in with Google
+        Register with Google
       </SocialButton>
       <Text align="center" spaceAfter="normal">
         OR

--- a/utils/api/auth.js
+++ b/utils/api/auth.js
@@ -234,6 +234,10 @@ class AuthAPI {
 
   async _googleAuth() {
     const provider = new firebase.auth.GoogleAuthProvider();
+    // allow user to select own account
+    provider.setCustomParameters({
+      prompt: 'select_account',
+    });
     return await firebaseAuth.signInWithPopup(provider);
   }
 


### PR DESCRIPTION
- Allow user to select for a particular google account instead of automatically selects the previous one
- Change from `sign in` -> `register`

Fixes issue 9 in google docs