### PR TITLE
Remove elastic scrolling in safari chat

### DIFF
--- a/src/components/chat/pages/ChatPage.js
+++ b/src/components/chat/pages/ChatPage.js
@@ -9,6 +9,7 @@ import { EMAIL_BAR_HEIGHT, NAVBAR_HEIGHT } from '../../../../utils/constants/nav
 import useMediaQuery from '@kiwicom/orbit-components/lib/hooks/useMediaQuery';
 import Router from 'next/router';
 import useWindowDimensions from '../../../../utils/hooks/useWindowDimensions';
+import { isSafari } from 'react-device-detect';
 
 const NoChatsContainer = styled.div`
   margin: 0 auto;
@@ -180,6 +181,7 @@ const ChatPage = ({ user, chatId, postId, postType, isViewingChatsForMyPost }) =
   const gridContainerStyle = {
     height: `${height - navBarOffsetHeight}px`,
     width: '100vw',
+    position: isSafari ? 'fixed' : 'initial', // disable elastic scroll in safari
   };
 
   if (hasError) {


### PR DESCRIPTION
Safari mobile has elastic scrolling/overscroll/bounce effect ([more info](https://www.bram.us/2016/05/02/prevent-overscroll-bounce-in-ios-mobilesafari-pure-css/)). 

Let's remove this to prevent chat not being scrollable as users are unable to overscroll the outer div of the chat.

Fixes the issue mentioned by @jinyingtan 