### PR TITLE
Update with empty string

### DIFF
--- a/src/components/inputfield/GooglePlacesAutoCompleteField.js
+++ b/src/components/inputfield/GooglePlacesAutoCompleteField.js
@@ -83,6 +83,10 @@ const GooglePlacesAutoCompleteField = ({ label, storeLocally, help, storageKey, 
       label={label}
       ref={autoCompleteRef}
       onChange={(event) => {
+        if (event.target.value.length === 0) {
+          setLocation('');
+          onChange('');
+        }
         setQuery(event.target.value);
       }}
       placeholder=""


### PR DESCRIPTION
In this PR,
- when GooglePlaces input field is empty, it will call `onChanged` as well and clear the localStorage