### PR TITLE
Remove redux from create-wish page

### DIFF
--- a/src/components/createWish/context.js
+++ b/src/components/createWish/context.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const WishContext = createContext();
+
+export default WishContext;

--- a/src/components/createWish/index.js
+++ b/src/components/createWish/index.js
@@ -1,5 +1,0 @@
-import * as selectors from './selectors';
-
-export { selectors };
-
-export { default } from './reducers';

--- a/src/components/createWish/initialState.js
+++ b/src/components/createWish/initialState.js
@@ -1,0 +1,8 @@
+const initialState = {
+  title: '',
+  description: '',
+  categories: [],
+  postedDateTime: '',
+};
+
+export default initialState;

--- a/src/components/createWish/modules/createWishPanel.js
+++ b/src/components/createWish/modules/createWishPanel.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import {
   Button,
   InputField,
@@ -13,7 +13,6 @@ import {
   TextLink,
   Alert,
 } from '@kiwicom/orbit-components/lib';
-import { useDispatch } from 'react-redux';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import api from '../../../../utils/api';
@@ -30,6 +29,7 @@ import { getExpireWishDate, getExpireWishDateFormat } from '../../../../utils/ap
 import GooglePlacesAutoCompleteField from '../../inputfield/GooglePlacesAutoCompleteField';
 import { logSuccessfullyCreatedWish } from '../../../../utils/analytics';
 import ExpirePostAlert from './ExpirePostAlert';
+import WishContext from '../context';
 
 const Container = styled.div`
   min-width: 300px;
@@ -37,7 +37,6 @@ const Container = styled.div`
 `;
 
 const CreateWishPanel = ({ wish, mode }) => {
-  const dispatch = useDispatch();
   const router = useRouter();
   const { isDesktop } = useMediaQuery();
   const [categories, setCategories] = useState([]);
@@ -49,6 +48,8 @@ const CreateWishPanel = ({ wish, mode }) => {
   const [alertType, setAlertType] = useState('');
   const [alertDescription, setAlertDescription] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+
+  const { state, dispatch } = useContext(WishContext);
 
   const displayAlert = (title, description, type) => {
     setShowAlert(true);
@@ -158,7 +159,7 @@ const CreateWishPanel = ({ wish, mode }) => {
       dispatch(setAllCategories(formik.values.categories));
       dispatch(setPostedDateTime(wish ? wish.postedDateTime : Date.now()));
     }
-  }, [formik, dispatch]);
+  }, [formik.values]);
 
   // Used to fetch all categories
   useEffect(() => {

--- a/src/components/createWish/modules/livePreviewPanel.js
+++ b/src/components/createWish/modules/livePreviewPanel.js
@@ -1,20 +1,21 @@
-import React from 'react';
-import { Stack, Heading, Text, Alert, Tooltip, TextLink } from '@kiwicom/orbit-components/lib';
-import { useSelector } from 'react-redux';
+import React, { useContext } from 'react';
+import { Stack, Heading, Text } from '@kiwicom/orbit-components/lib';
 import styled from 'styled-components';
 import WishCard from '../../card/WishCard';
 import { getTitle, getDescription, getCategories, getPostedDateTime } from '../selectors';
 import useUser from '../../session/modules/useUser';
+import WishContext from '../context';
 
 const Container = styled.div`
   padding: 20px;
 `;
 
 const LivePreviewPanel = () => {
-  const title = useSelector(getTitle);
-  const description = useSelector(getDescription);
-  const categories = useSelector(getCategories);
-  const postedDateTime = useSelector(getPostedDateTime);
+  const { state } = useContext(WishContext);
+  const title = getTitle(state);
+  const description = getDescription(state);
+  const categories = getCategories(state);
+  const postedDateTime = getPostedDateTime(state);
   const user = useUser();
 
   if (!user) {

--- a/src/components/createWish/pages/createWishPage.js
+++ b/src/components/createWish/pages/createWishPage.js
@@ -1,10 +1,14 @@
-import React from 'react';
+import React, { useReducer, useMemo } from 'react';
 import styled, { css } from 'styled-components';
 import media from '@kiwicom/orbit-components/lib/utils/mediaQuery';
 
 import CreateWishPanel from '../modules/createWishPanel';
 import LivePreviewPanel from '../modules/livePreviewPanel';
 import useMediaQuery from '@kiwicom/orbit-components/lib/hooks/useMediaQuery';
+
+import initialState from '../initialState';
+import reducer from '../reducers';
+import WishContext from '../context';
 
 const Container = styled.div`
   display: flex;
@@ -38,15 +42,23 @@ const Wrapper = styled.div`
 `;
 
 const CreateWishPage = ({ wish, mode }) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
   const { isDesktop } = useMediaQuery();
 
+  // prevent re-rendering
+  const contextValue = useMemo(() => {
+    return { state, dispatch };
+  }, [state, dispatch]);
+
   return (
-    <Container>
-      <Wrapper>
-        <CreateWishPanel wish={wish} mode={mode} />
-        {isDesktop ? <LivePreviewPanel /> : null}
-      </Wrapper>
-    </Container>
+    <WishContext.Provider value={contextValue}>
+      <Container>
+        <Wrapper>
+          <CreateWishPanel wish={wish} mode={mode} />
+          {isDesktop ? <LivePreviewPanel /> : null}
+        </Wrapper>
+      </Container>
+    </WishContext.Provider>
   );
 };
 

--- a/src/components/createWish/reducers.js
+++ b/src/components/createWish/reducers.js
@@ -1,9 +1,4 @@
-const initialState = {
-  title: '',
-  description: '',
-  categories: [],
-  postedDateTime: '',
-};
+import initialState from './initialState';
 
 const createWishReducer = (state = initialState, action) => {
   switch (action.type) {

--- a/src/components/createWish/selectors.js
+++ b/src/components/createWish/selectors.js
@@ -1,19 +1,15 @@
-function getLocalState(state) {
-  return state.createWish;
-}
-
 export function getTitle(state) {
-  return getLocalState(state).title;
+  return state.title;
 }
 
 export function getDescription(state) {
-  return getLocalState(state).description;
+  return state.description;
 }
 
 export function getCategories(state) {
-  return getLocalState(state).categories;
+  return state.categories;
 }
 
 export function getPostedDateTime(state) {
-  return getLocalState(state).postedDateTime;
+  return state.postedDateTime;
 }

--- a/store.js
+++ b/store.js
@@ -5,7 +5,6 @@ import logger from 'redux-logger';
 import registerReducer from './src/components/register';
 import loginReducer from './src/components/login';
 import sessionReducer from './src/components/session';
-import createWishReducer from './src/components/createWish';
 import createDonationReducer from './src/components/createDonation';
 import navbarReducer from './src/components/navbar';
 
@@ -15,7 +14,6 @@ const rootReducer = combineReducers({
   register: registerReducer,
   login: loginReducer,
   session: sessionReducer,
-  createWish: createWishReducer,
   createDonation: createDonationReducer,
   navbar: navbarReducer,
 });


### PR DESCRIPTION
In this PR,
- Used `useReducer` with `useContext` to expose `state and dispatch` to all the components within `createWish`

Reason:
- There is no need for creating of wishes to be store in global store. 
- While there may be more boiler plate files, it is beneficial that we do not pollute the global store unnecessary 