### PR TITLE
Remove redux from create-donation page

### DIFF
--- a/src/components/createDonation/context.js
+++ b/src/components/createDonation/context.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const DonationContext = createContext();
+
+export default DonationContext;

--- a/src/components/createDonation/index.js
+++ b/src/components/createDonation/index.js
@@ -1,5 +1,0 @@
-import * as selectors from './selectors';
-
-export { selectors };
-
-export { default } from './reducers';

--- a/src/components/createDonation/initialState.js
+++ b/src/components/createDonation/initialState.js
@@ -1,0 +1,11 @@
+const initialState = {
+  title: '',
+  description: '',
+  categories: [],
+  validFrom: '',
+  validTo: '',
+  coverImage: null,
+  location: '',
+};
+
+export default initialState;

--- a/src/components/createDonation/modules/createDonationPanel.js
+++ b/src/components/createDonation/modules/createDonationPanel.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import RedButton from '../../buttons/RedButton';
 import {
   Button,
@@ -43,6 +43,7 @@ import { getDay, getMonth, getYear } from '../../../../utils/api/time';
 import { v4 as uuidv4 } from 'uuid';
 import MrtDropdownField from '../../inputfield/MrtDropdownField';
 import { logSuccessfullyCreatedDonation } from '../../../../utils/analytics';
+import DonationContext from '../context';
 
 const Container = styled.div`
   min-width: 300px;
@@ -81,7 +82,7 @@ const validateDateRange = (fromDay, fromMonth, fromYear, toDay, toMonth, toYear)
 };
 
 const CreateDonationPanel = ({ mode, donation }) => {
-  const dispatch = useDispatch();
+  const { state, dispatch } = useContext(DonationContext);
   const router = useRouter();
   const [categories, setCategories] = useState([]);
   const [selectedCategories, setSelectedCategories] = useState([]);
@@ -385,7 +386,7 @@ const CreateDonationPanel = ({ mode, donation }) => {
         setValidTo(formik.values.validToDay + '/' + formik.values.validToMonth + '/' + formik.values.validToYear)
       );
     }
-  }, [formik, dispatch]);
+  }, [formik.values]);
 
   // Used to edit donation
   useEffect(() => {

--- a/src/components/createDonation/modules/livePreviewDonation.js
+++ b/src/components/createDonation/modules/livePreviewDonation.js
@@ -1,28 +1,30 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Stack, Heading, Text } from '@kiwicom/orbit-components/lib';
-import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import DonationCard from '../../card/DonationCard';
 import { getTitle, getDescription, getCoverImage, getLocation, getValidFrom, getValidTo } from '../selectors';
 import useUser from '../../session/modules/useUser';
+import DonationContext from '../context';
 
 const Container = styled.div`
   padding: 20px;
 `;
 
 const LivePreviewDonation = () => {
+  const { state } = useContext(DonationContext);
   const user = useUser();
-  const title = useSelector(getTitle);
-  const description = useSelector(getDescription);
-  const coverImage = useSelector(getCoverImage);
-  const location = useSelector(getLocation);
-  const validFrom = useSelector(getValidFrom);
-  const validTo = useSelector(getValidTo);
-  const profileHref = `/profile/${user._id}`;
+  const title = getTitle(state);
+  const description = getDescription(state);
+  const coverImage = getCoverImage(state);
+  const location = getLocation(state);
+  const validFrom = getValidFrom(state);
+  const validTo = getValidTo(state);
 
   if (!user) {
     return null;
   }
+
+  const profileHref = `/profile/${user.userId}`;
 
   return (
     <Stack align="center" direction="column" basis="50%">

--- a/src/components/createDonation/modules/livePreviewDonation.js
+++ b/src/components/createDonation/modules/livePreviewDonation.js
@@ -23,7 +23,6 @@ const LivePreviewDonation = () => {
   if (!user) {
     return null;
   }
-  const profileHref = `/profile/${user.userId}`;
 
   const profileHref = `/profile/${user.userId}`;
 

--- a/src/components/createDonation/pages/createDonationPage.js
+++ b/src/components/createDonation/pages/createDonationPage.js
@@ -1,8 +1,12 @@
-import React from 'react';
+import React, { useReducer, useMemo } from 'react';
 import styled, { css } from 'styled-components';
 import media from '@kiwicom/orbit-components/lib/utils/mediaQuery';
 import CreateDonationPanel from '../modules/createDonationPanel';
 import { Heading, Alert, Stack } from '@kiwicom/orbit-components/lib';
+
+import initialState from '../initialState';
+import reducer from '../reducers';
+import DonationContext from '../context';
 
 const Container = styled.div`
   display: flex;
@@ -46,22 +50,31 @@ const HeadingWrapper = styled.div`
 `;
 
 const CreateDonationPage = ({ mode, donation }) => {
-  return (
-    <Container>
-      <HeadingWrapper>
-        <Stack spacing="loose">
-          <Heading>What are you donating today?</Heading>
-          <Alert icon title="Some additional information" type="info">
-            As a donor, you are <b>encouraged</b> to cover the delivery cost (if there is) to the specified location.
-            This is to encourage donations of good and usable items to the beneficiaries or organizations.
-          </Alert>
-        </Stack>
-      </HeadingWrapper>
+  const [state, dispatch] = useReducer(reducer, initialState);
 
-      <Wrapper>
-        <CreateDonationPanel mode={mode} donation={donation} />
-      </Wrapper>
-    </Container>
+  // prevent re-rendering
+  const contextValue = useMemo(() => {
+    return { state, dispatch };
+  }, [state, dispatch]);
+
+  return (
+    <DonationContext.Provider value={contextValue}>
+      <Container>
+        <HeadingWrapper>
+          <Stack spacing="loose">
+            <Heading>What are you donating today?</Heading>
+            <Alert icon title="Some additional information" type="info">
+              As a donor, you are <b>encouraged</b> to cover the delivery cost (if there is) to the specified location.
+              This is to encourage donations of good and usable items to the beneficiaries or organizations.
+            </Alert>
+          </Stack>
+        </HeadingWrapper>
+
+        <Wrapper>
+          <CreateDonationPanel mode={mode} donation={donation} />
+        </Wrapper>
+      </Container>
+    </DonationContext.Provider>
   );
 };
 

--- a/src/components/createDonation/reducers.js
+++ b/src/components/createDonation/reducers.js
@@ -1,12 +1,4 @@
-const initialState = {
-  title: '',
-  description: '',
-  categories: [],
-  validFrom: '',
-  validTo: '',
-  coverImage: null,
-  location: '',
-};
+import initialState from './initialState';
 
 const createDonationReducer = (state = initialState, action) => {
   switch (action.type) {

--- a/src/components/createDonation/selectors.js
+++ b/src/components/createDonation/selectors.js
@@ -1,31 +1,27 @@
-function getLocalState(state) {
-  return state.createDonation;
-}
-
 export function getTitle(state) {
-  return getLocalState(state).title;
+  return state.title;
 }
 
 export function getDescription(state) {
-  return getLocalState(state).description;
+  return state.description;
 }
 
 export function getCategories(state) {
-  return getLocalState(state).categories;
+  return state.categories;
 }
 
 export function getValidFrom(state) {
-  return getLocalState(state).validFrom;
+  return state.validFrom;
 }
 
 export function getValidTo(state) {
-  return getLocalState(state).validTo;
+  return state.validTo;
 }
 
 export function getLocation(state) {
-  return getLocalState(state).location;
+  return state.location;
 }
 
 export function getCoverImage(state) {
-  return getLocalState(state).coverImage;
+  return state.coverImage;
 }

--- a/store.js
+++ b/store.js
@@ -6,7 +6,6 @@ import registerReducer from './src/components/register';
 import loginReducer from './src/components/login';
 import sessionReducer from './src/components/session';
 import createWishReducer from './src/components/createWish';
-import createDonationReducer from './src/components/createDonation';
 import navbarReducer from './src/components/navbar';
 
 const initialState = {};
@@ -16,7 +15,6 @@ const rootReducer = combineReducers({
   login: loginReducer,
   session: sessionReducer,
   createWish: createWishReducer,
-  createDonation: createDonationReducer,
   navbar: navbarReducer,
 });
 


### PR DESCRIPTION
In this PR,
- Used `useReducer` with `useContext` to expose `state and dispatch` to all the components within `createWish`

Reason:
- There is no need for creating of donation to be store in global store. 
- While there may be more boiler plate files, it is beneficial that we do not pollute the global store unnecessary 