### PR TITLE
Add conditionally show when no chats available

### DIFF
--- a/src/components/chat/modules/ListOfChats.js
+++ b/src/components/chat/modules/ListOfChats.js
@@ -32,6 +32,9 @@ const EmptyChatContainer = styled.div`
   height: 100%;
   width: 100%;
   border-right: 1px solid ${colors.chatBorders};
+  display: ${({ isShow }) => {
+    return isShow ? 'unset' : 'none';
+  }};
 `;
 
 const EmptyChatTextContainer = styled.div`
@@ -148,7 +151,7 @@ const ListOfChats = ({ isShow }) => {
 
   if (isMounted && chatDocs.length === 0) {
     return (
-      <EmptyChatContainer>
+      <EmptyChatContainer isShow={isShow}>
         <EmptyChatTextContainer>No chats available.</EmptyChatTextContainer>
       </EmptyChatContainer>
     );


### PR DESCRIPTION
The empty chat text container still shows even in mobile view, causing weird UI.

![IMG_2922](https://user-images.githubusercontent.com/32864116/93316717-270ccd80-f83f-11ea-904d-91389d68a465.PNG)
