### PR TITLE
Add onboarding ui

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import SessionProvider from '@components/session/modules/SessionProvider';
-import useUser from '@components/session/modules/useUser';
 import { isAuthenticated } from '@utils/authentication/authentication';
-import Verified from '@components/session/modules/Verified';
 import WishesHomePage from '@components/home/pages/WishesHomePage';
 import dynamic from 'next/dynamic';
 import Header from '@components/header';
 import { WISHES } from '@constants/search';
+import Onboarding from '@components/onboarding/Onboarding';
+import { DONOR, NPO } from '@constants/usersType';
 
 const TopNavigationBar = dynamic(() => import('@components/navbar/modules/TopNavigationBar'), { ssr: false });
 const BottomNavigation = dynamic(() => import('@components/navbar/modules/BottomNavigation'), { ssr: false });
@@ -14,15 +14,16 @@ const Footer = dynamic(() => import('@components/footer/Footer'), { ssr: false }
 
 export async function getServerSideProps({ params, req, res, query }) {
   let user = await isAuthenticated(req, res);
+  const { next } = query;
   return {
     props: {
       user,
+      next: next || null,
     },
   };
 }
 
-const WishesHome = ({ user }) => {
-  const userData = useUser();
+const WishesHome = ({ user, next }) => {
   return (
     <SessionProvider user={user}>
       <Header title="Wishes | GiftForGood" />
@@ -30,6 +31,12 @@ const WishesHome = ({ user }) => {
       <WishesHomePage />
       <BottomNavigation />
       <Footer />
+
+      <Onboarding
+        show={user && next === 'onboarding' ? true : false}
+        type={user?.user?.donor ? DONOR : NPO}
+        name={user?.user?.name}
+      />
     </SessionProvider>
   );
 };

--- a/src/components/onboarding/Onboarding.js
+++ b/src/components/onboarding/Onboarding.js
@@ -57,6 +57,7 @@ const Onboarding = ({ type, show = false, name = '' }) => {
   const [shown, setShown] = useState(show);
   const [currentSlide, setCurrentSlide] = useState(0);
   const [onboardingContent, setOnboardingContent] = useState(type === DONOR ? onboardingDonor : onboardingNpo);
+  const [buttonLabel, setButtonLabel] = useState('Next');
 
   const updateCurrentSlide = (index) => {
     if (currentSlide !== index) {
@@ -115,9 +116,17 @@ const Onboarding = ({ type, show = false, name = '' }) => {
               </ButtonLink>
               <Button
                 asComponent={type === DONOR ? RedButton : BlueButton}
-                onClick={() => setCurrentSlide(currentSlide + 1)}
+                onClick={() => {
+                  setCurrentSlide(currentSlide + 1);
+                  if (currentSlide + 2 === onboardingContent.length) {
+                    setButtonLabel('Done');
+                  }
+                  if (currentSlide + 1 === onboardingContent.length) {
+                    closeOnboarding();
+                  }
+                }}
               >
-                Next
+                {buttonLabel}
               </Button>
             </Stack>
           </ModalSection>

--- a/src/components/onboarding/Onboarding.js
+++ b/src/components/onboarding/Onboarding.js
@@ -11,6 +11,7 @@ import { DONOR } from '@constants/usersType';
 import { colors } from '@constants/colors';
 import BlueButton from '@components/buttons/BlueButton';
 import RedButton from '@components/buttons/RedButton';
+import Linkify from 'react-linkify';
 
 const Image = styled.img`
   height: 200px;
@@ -36,7 +37,16 @@ const BannerContent = ({ src, description }) => {
   return (
     <BannerContentContainer>
       <Image src={src} />
-      <Text align="center">{description}</Text>
+
+      <Linkify
+        componentDecorator={(decoratedHref, decoratedText, key) => (
+          <a target="blank" href={decoratedHref} key={key}>
+            {decoratedText}
+          </a>
+        )}
+      >
+        <Text align="center">{description}</Text>
+      </Linkify>
     </BannerContentContainer>
   );
 };

--- a/src/components/onboarding/Onboarding.js
+++ b/src/components/onboarding/Onboarding.js
@@ -12,6 +12,7 @@ import { colors } from '@constants/colors';
 import BlueButton from '@components/buttons/BlueButton';
 import RedButton from '@components/buttons/RedButton';
 import Linkify from 'react-linkify';
+import { useRouter } from 'next/router';
 
 const Image = styled.img`
   height: 200px;
@@ -52,6 +53,7 @@ const BannerContent = ({ src, description }) => {
 };
 
 const Onboarding = ({ type, show = false, name = '' }) => {
+  const router = useRouter();
   const [shown, setShown] = useState(show);
   const [currentSlide, setCurrentSlide] = useState(0);
   const [onboardingContent, setOnboardingContent] = useState(type === DONOR ? onboardingDonor : onboardingNpo);
@@ -62,10 +64,17 @@ const Onboarding = ({ type, show = false, name = '' }) => {
     }
   };
 
+  const closeOnboarding = () => {
+    setShown(false);
+    router.push('/', '/', {
+      shallow: true,
+    });
+  };
+
   return (
     <>
       {shown ? (
-        <Modal onClose={() => setShown(false)} size="small">
+        <Modal onClose={closeOnboarding} size="small">
           <ModalHeader title={`Welcome, ${name}!`}></ModalHeader>
           <ModalSection>
             <Carousel
@@ -101,7 +110,7 @@ const Onboarding = ({ type, show = false, name = '' }) => {
             </Carousel>
 
             <Stack direction="row" justify="between">
-              <ButtonLink onClick={() => setShown(false)} type="secondary">
+              <ButtonLink onClick={closeOnboarding} type="secondary">
                 Skip intro
               </ButtonLink>
               <Button

--- a/src/components/onboarding/Onboarding.js
+++ b/src/components/onboarding/Onboarding.js
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Modal, Text, Stack } from '@kiwicom/orbit-components/lib';
+import { ModalSection, ModalHeader } from '@kiwicom/orbit-components/lib/Modal';
+import { Carousel } from 'react-responsive-carousel';
+import Button from '@kiwicom/orbit-components/lib/Button';
+import ButtonLink from '@kiwicom/orbit-components/lib/ButtonLink';
+import { onboardingDonor, onboardingNpo } from '@constants/onboarding';
+import { DONOR } from '@constants/usersType';
+import { colors } from '@constants/colors';
+import BlueButton from '@components/buttons/BlueButton';
+import RedButton from '@components/buttons/RedButton';
+
+const Image = styled.img`
+  height: 200px;
+  width: 100%;
+  margin-bottom: 50px;
+`;
+
+const BannerContentContainer = styled.div`
+  margin-bottom: 50px;
+`;
+
+const Indicator = styled.li`
+  background: ${({ selected, type }) =>
+    selected ? (type === DONOR ? colors.donorBackground : colors.npoBackground) : '#bdbdbd'};
+  width: 10px;
+  height: 10px;
+  display: inline-block;
+  margin: 0 8px;
+  border-radius: 10px;
+`;
+
+const BannerContent = ({ src, description }) => {
+  return (
+    <BannerContentContainer>
+      <Image src={src} />
+      <Text align="center">{description}</Text>
+    </BannerContentContainer>
+  );
+};
+
+const Onboarding = ({ type, show = false, name = '' }) => {
+  const [shown, setShown] = useState(show);
+  const [currentSlide, setCurrentSlide] = useState(0);
+  const [onboardingContent, setOnboardingContent] = useState(type === DONOR ? onboardingDonor : onboardingNpo);
+
+  const updateCurrentSlide = (index) => {
+    if (currentSlide !== index) {
+      setCurrentSlide(index);
+    }
+  };
+
+  return (
+    <>
+      {shown ? (
+        <Modal onClose={() => setShown(false)} size="small">
+          <ModalHeader title={`Welcome, ${name}!`}></ModalHeader>
+          <ModalSection>
+            <Carousel
+              showThumbs={false}
+              showStatus={false}
+              autoPlay={false}
+              stopOnHover
+              showArrows={false}
+              selectedItem={currentSlide}
+              onChange={updateCurrentSlide}
+              renderIndicator={(onClickHandler, isSelected, index, label) => {
+                if (isSelected) {
+                  return <Indicator selected={isSelected} type={type} />;
+                }
+                return (
+                  <Indicator
+                    onClick={onClickHandler}
+                    onKeyDown={onClickHandler}
+                    value={index}
+                    key={index}
+                    role="button"
+                    tabIndex={0}
+                    title={`${label} ${index + 1}`}
+                    aria-label={`${label} ${index + 1}`}
+                    type={type}
+                  />
+                );
+              }}
+            >
+              {onboardingContent.map((content) => (
+                <BannerContent src={content.src} description={content.description} />
+              ))}
+            </Carousel>
+
+            <Stack direction="row" justify="between">
+              <ButtonLink onClick={() => setShown(false)} type="secondary">
+                Skip intro
+              </ButtonLink>
+              <Button
+                asComponent={type === DONOR ? RedButton : BlueButton}
+                onClick={() => setCurrentSlide(currentSlide + 1)}
+              >
+                Next
+              </Button>
+            </Stack>
+          </ModalSection>
+        </Modal>
+      ) : null}
+    </>
+  );
+};
+
+Onboarding.propTypes = {
+  type: PropTypes.string.isRequired,
+  show: PropTypes.bool.isRequired,
+  name: PropTypes.string.isRequired,
+};
+
+export default Onboarding;

--- a/src/components/register/modules/RegisterDonor.js
+++ b/src/components/register/modules/RegisterDonor.js
@@ -64,7 +64,7 @@ const RegisterDonor = () => {
       let response = await client.post('/api/sessionLogin', { token });
       if (response.status === 200) {
         await timeout(1000);
-        router.push('/');
+        router.push('/?next=onboarding');
       } else {
         throw response.error;
       }

--- a/src/components/register/modules/RegisterNpoDetails.js
+++ b/src/components/register/modules/RegisterNpoDetails.js
@@ -84,7 +84,7 @@ const RegisterNpoDetails = () => {
       let response = await client.post('/api/sessionLogin', { token });
       if (response.status === 200) {
         await timeout(1000);
-        router.push('/');
+        router.push('/?next=onboarding');
       } else {
         throw response.error;
       }

--- a/utils/constants/onboarding.js
+++ b/utils/constants/onboarding.js
@@ -1,0 +1,24 @@
+export const onboardingDonor = [
+  {
+    src: 'https://res.cloudinary.com/giftforgood/image/upload/v1601521851/onboarding/undraw_send_gift_7o4m_lat4mf.svg',
+    description: 'You can donate by posting your items and wait for NPOs to chat with you.',
+  },
+  {
+    src: 'https://res.cloudinary.com/giftforgood/image/upload/v1601521853/onboarding/undraw_chatting_2yvo_jzcdik.svg',
+    description: 'You can donate by chatting with wishes on the platform and see how you can help.',
+  },
+];
+
+export const onboardingNpo = [
+  {
+    src:
+      'https://res.cloudinary.com/giftforgood/image/upload/v1601533846/onboarding/undraw_publish_post_vowb_lhsz01.svg',
+    description:
+      'You can request for items by posting a wish, with a title, description and location of delivery. Donors will be able to view them in individual category page.',
+  },
+  {
+    src: 'https://res.cloudinary.com/giftforgood/image/upload/v1601533848/onboarding/undraw_chatting_2yvo_1_f78qcq.svg',
+    description:
+      'You can request for donations by chatting with donations on the platform and see how they can help you.',
+  },
+];

--- a/utils/constants/onboarding.js
+++ b/utils/constants/onboarding.js
@@ -8,7 +8,7 @@ export const onboardingDonor = [
     description: 'Chat with NPOs to confirm your donation',
   },
   {
-    src: 'https://res.cloudinary.com/giftforgood/image/upload/v1602139758/onboarding/undraw_Savings_re_eq4w_moc7yu.svg',
+    src: 'https://res.cloudinary.com/giftforgood/image/upload/v1602142785/onboarding/undraw_discount_d4bd_jutjwn.svg',
     description: 'Use our promo codes for discounted delivery rates! https://www.giftforgood.io/delivery-partners',
   },
 ];
@@ -24,8 +24,7 @@ export const onboardingNpo = [
     description: 'Chat with donors to accept their donations',
   },
   {
-    src:
-      'https://res.cloudinary.com/giftforgood/image/upload/v1602139760/onboarding/undraw_Savings_re_eq4w_1_qfcbum.svg',
+    src: 'https://res.cloudinary.com/giftforgood/image/upload/v1602142787/onboarding/undraw_discount_d4bd_1_djsvsl.svg',
     description: 'Use our promo codes for discounted delivery rates! https://www.giftforgood.io/delivery-partners',
   },
 ];

--- a/utils/constants/onboarding.js
+++ b/utils/constants/onboarding.js
@@ -9,24 +9,23 @@ export const onboardingDonor = [
   },
   {
     src: 'https://res.cloudinary.com/giftforgood/image/upload/v1602139758/onboarding/undraw_Savings_re_eq4w_moc7yu.svg',
-    description: 'Use our promo codes for discounted delivery rates! https://www.giftforgood.io/delivery-partners'
-  }
+    description: 'Use our promo codes for discounted delivery rates! https://www.giftforgood.io/delivery-partners',
+  },
 ];
 
 export const onboardingNpo = [
   {
     src:
       'https://res.cloudinary.com/giftforgood/image/upload/v1601533846/onboarding/undraw_publish_post_vowb_lhsz01.svg',
-    description:
-      'You can now post your wishes or check out items listed by donors!',
+    description: 'You can now post your wishes or check out items listed by donors!',
   },
   {
     src: 'https://res.cloudinary.com/giftforgood/image/upload/v1601533848/onboarding/undraw_chatting_2yvo_1_f78qcq.svg',
-    description:
-      'Chat with donors to accept their donations',
+    description: 'Chat with donors to accept their donations',
   },
   {
-    src: 'https://res.cloudinary.com/giftforgood/image/upload/v1602139760/onboarding/undraw_Savings_re_eq4w_1_qfcbum.svg',
-    description: 'Use our promo codes for discounted delivery rates! https://www.giftforgood.io/delivery-partners'
-  }
+    src:
+      'https://res.cloudinary.com/giftforgood/image/upload/v1602139760/onboarding/undraw_Savings_re_eq4w_1_qfcbum.svg',
+    description: 'Use our promo codes for discounted delivery rates! https://www.giftforgood.io/delivery-partners',
+  },
 ];

--- a/utils/constants/onboarding.js
+++ b/utils/constants/onboarding.js
@@ -1,12 +1,16 @@
 export const onboardingDonor = [
   {
     src: 'https://res.cloudinary.com/giftforgood/image/upload/v1601521851/onboarding/undraw_send_gift_7o4m_lat4mf.svg',
-    description: 'You can donate by posting your items and wait for NPOs to chat with you.',
+    description: 'Start donating by browsing wishes or listing your items for donation!',
   },
   {
     src: 'https://res.cloudinary.com/giftforgood/image/upload/v1601521853/onboarding/undraw_chatting_2yvo_jzcdik.svg',
-    description: 'You can donate by chatting with wishes on the platform and see how you can help.',
+    description: 'Chat with NPOs to confirm your donation',
   },
+  {
+    src: 'https://res.cloudinary.com/giftforgood/image/upload/v1602139758/onboarding/undraw_Savings_re_eq4w_moc7yu.svg',
+    description: 'Use our promo codes for discounted delivery rates! https://www.giftforgood.io/delivery-partners'
+  }
 ];
 
 export const onboardingNpo = [
@@ -14,11 +18,15 @@ export const onboardingNpo = [
     src:
       'https://res.cloudinary.com/giftforgood/image/upload/v1601533846/onboarding/undraw_publish_post_vowb_lhsz01.svg',
     description:
-      'You can request for items by posting a wish, with a title, description and location of delivery. Donors will be able to view them in individual category page.',
+      'You can now post your wishes or check out items listed by donors!',
   },
   {
     src: 'https://res.cloudinary.com/giftforgood/image/upload/v1601533848/onboarding/undraw_chatting_2yvo_1_f78qcq.svg',
     description:
-      'You can request for donations by chatting with donations on the platform and see how they can help you.',
+      'Chat with donors to accept their donations',
   },
+  {
+    src: 'https://res.cloudinary.com/giftforgood/image/upload/v1602139760/onboarding/undraw_Savings_re_eq4w_1_qfcbum.svg',
+    description: 'Use our promo codes for discounted delivery rates! https://www.giftforgood.io/delivery-partners'
+  }
 ];


### PR DESCRIPTION
In this PR,
- Added Onboarding modal UI for donor and NPO
- Accessible via `?next=onboarding`

Todo:
- [x] Get updated descriptions
- [x] Update register page to route to correct page with query
- [x] shallow route to home page when `skip` and `close`


![IMAGE 2020-10-01 15:37:44](https://user-images.githubusercontent.com/8737187/94781176-0d04ea80-03fc-11eb-82f6-a67ded0cbcce.jpg)
![IMAGE 2020-10-01 15:37:53](https://user-images.githubusercontent.com/8737187/94781192-12623500-03fc-11eb-8d55-4cc44ac72bb5.jpg)
![IMAGE 2020-10-01 15:38:13](https://user-images.githubusercontent.com/8737187/94781229-1e4df700-03fc-11eb-88a3-8e4f234fd9c9.jpg)


