### PR TITLE
Redirect back to chat after login

### DIFF
--- a/pages/chat/index.js
+++ b/pages/chat/index.js
@@ -22,11 +22,8 @@ const TopNavigationBar = dynamic(() => import('@components/navbar/modules/TopNav
 export async function getServerSideProps({ params, req, res, query }) {
   const user = await isAuthenticated(req, res);
   if (!user) {
-    return {
-      props: {
-        hasError: true,
-      },
-    };
+    res.writeHead(302, { Location: `/login?redirect=${req.url}` });
+    res.end();
   }
 
   if (!user.user.emailVerified) {

--- a/pages/login.js
+++ b/pages/login.js
@@ -11,18 +11,20 @@ export async function getServerSideProps({ params, req, res, query }) {
     res.writeHead(302, { Location: '/' });
     res.end();
   }
+  let redirectUrlAfterLogin = query.redirect ? query.redirect : null;
   return {
     props: {
       user,
+      redirectUrlAfterLogin,
     },
   };
 }
 
-const Login = () => {
+const Login = ({ redirectUrlAfterLogin }) => {
   return (
     <div>
       <Header title="Login | GiftForGood" />
-      <LoginPage />
+      <LoginPage redirectUrlAfterLogin={redirectUrlAfterLogin} />
     </div>
   );
 };

--- a/src/components/login/modules/LoginDonor.js
+++ b/src/components/login/modules/LoginDonor.js
@@ -20,7 +20,7 @@ const HeadingColor = styled.div`
   color: ${colors.donorBackground};
 `;
 
-const LoginDonor = () => {
+const LoginDonor = ({ redirectUrlAfterLogin }) => {
   const dispatch = useDispatch();
   const [alertTitle, setAlertTitle] = useState('');
   const [showAlert, setShowAlert] = useState(false);
@@ -48,7 +48,11 @@ const LoginDonor = () => {
       let userData = userDoc.data();
       let response = await client.post('/api/sessionLogin', { token });
       if (response.status === 200) {
-        router.push('/');
+        if (redirectUrlAfterLogin) {
+          router.push(redirectUrlAfterLogin);
+        } else {
+          router.push('/');
+        }
       } else {
         throw response.error;
       }
@@ -82,7 +86,11 @@ const LoginDonor = () => {
       let userData = userDoc.data();
       let response = await client.post('/api/sessionLogin', { token });
       if (response.status === 200) {
-        router.push('/');
+        if (redirectUrlAfterLogin) {
+          router.push(redirectUrlAfterLogin);
+        } else {
+          router.push('/');
+        }
       } else {
         throw response.error;
       }

--- a/src/components/login/modules/LoginNpo.js
+++ b/src/components/login/modules/LoginNpo.js
@@ -18,7 +18,7 @@ const HeadingColor = styled.div`
   color: ${colors.npoBackground};
 `;
 
-const LoginNpo = () => {
+const LoginNpo = ({ redirectUrlAfterLogin }) => {
   const dispatch = useDispatch();
   const router = useRouter();
   const [alertTitle, setAlertTitle] = useState('');
@@ -45,7 +45,11 @@ const LoginNpo = () => {
       let userData = userDoc.data();
       let response = await client.post('/api/sessionLogin', { token });
       if (response.status === 200) {
-        router.push('/');
+        if (redirectUrlAfterLogin) {
+          router.push(redirectUrlAfterLogin);
+        } else {
+          router.push('/');
+        }
       } else {
         throw response.error;
       }

--- a/src/components/login/pages/LoginPage.js
+++ b/src/components/login/pages/LoginPage.js
@@ -47,7 +47,7 @@ const Panel = styled.div`
   `)};
 `;
 
-const LoginPage = (props, state) => {
+const LoginPage = ({ redirectUrlAfterLogin }) => {
   const currentPage = useSelector(getCurrentPage);
 
   function panel(currentPage) {
@@ -55,9 +55,9 @@ const LoginPage = (props, state) => {
       case LANDING:
         return <LoginLanding />;
       case NPO_LOGIN:
-        return <LoginNpo />;
+        return <LoginNpo redirectUrlAfterLogin={redirectUrlAfterLogin} />;
       case DONOR_LOGIN:
-        return <LoginDonor />;
+        return <LoginDonor redirectUrlAfterLogin={redirectUrlAfterLogin} />;
       default:
         return <LoginLanding />;
     }


### PR DESCRIPTION
```
Currently, when a not-logged-in user accesses a chat from a 
particular chat email, he/she will be redirected to an error page. 

Let's modify such that the user will first be redirected to the 
login page. After logging in, the user will be redirected back to
the originating chat page that he/she was supposed to be.
```