### PR TITLE
Fix/css buttons

### DIFF
--- a/src/components/buttons/BlackButton.js
+++ b/src/components/buttons/BlackButton.js
@@ -13,6 +13,11 @@ const BlackButton = styled.button`
     background: ${colors.loginHoverActive};
   }
 
+  :focus:not(:focus-visible) {
+    background: ${colors.loginHoverActive};
+    box-shadow: 0 0 0 3px rgba(46, 46, 46, 0.5);
+  }
+
   :focus {
     box-shadow: 0 0 0 3px rgba(46, 46, 46, 0.5);
   }

--- a/src/components/buttons/BlueButton.js
+++ b/src/components/buttons/BlueButton.js
@@ -12,6 +12,11 @@ const BlueButton = styled.button`
     background: ${colors.npoHoverActive};
   }
 
+  :focus:not(:focus-visible) {
+    background: ${colors.npoHoverActive};
+    box-shadow: 0 0 0 3px rgba(4, 65, 170, 0.5);
+  }
+
   :focus {
     box-shadow: 0 0 0 3px rgba(4, 65, 170, 0.5);
   }

--- a/src/components/buttons/CalendarButton.js
+++ b/src/components/buttons/CalendarButton.js
@@ -23,6 +23,11 @@ const CalendarButtonStyle = styled.button`
   :focus {
     box-shadow: 0 0 0 3px rgba(37, 42, 49, 0.16), 0px 2px 8px 0px rgba(37, 42, 49, 0.12);
   }
+
+  :focus:not(:focus-visible) {
+    background: Transparent;
+    box-shadow: 0 0 0 3px rgba(37, 42, 49, 0.16), 0px 2px 8px 0px rgba(37, 42, 49, 0.12);
+  }
 `;
 
 const CalendarButton = ({ dateTime, onClickHandler, isByLoggedInUser }) => {

--- a/src/components/buttons/CallToActionButton.js
+++ b/src/components/buttons/CallToActionButton.js
@@ -28,7 +28,7 @@ const CallToActionButtonStyle = styled.button`
 
   :focus:not(:focus-visible) {
     background: ${colors.donorHoverActive};
-    box-shadow: 0 0 0 3px rgba(222, 24, 24, 0.5) ;
+    box-shadow: 0 0 0 3px rgba(222, 24, 24, 0.5);
   }
 
   :focus {
@@ -51,7 +51,7 @@ const BottomCallToActionButtonStyle = styled.button`
 
   :focus:not(:focus-visible) {
     background: ${colors.donorHoverActive};
-    box-shadow: 0 0 0 3px rgba(222, 24, 24, 0.5) ;
+    box-shadow: 0 0 0 3px rgba(222, 24, 24, 0.5);
   }
 
   :focus {

--- a/src/components/buttons/CallToActionButton.js
+++ b/src/components/buttons/CallToActionButton.js
@@ -26,6 +26,11 @@ const CallToActionButtonStyle = styled.button`
     background: ${colors.donorHoverActive};
   }
 
+  :focus:not(:focus-visible) {
+    background: ${colors.donorHoverActive};
+    box-shadow: 0 0 0 3px rgba(222, 24, 24, 0.5) ;
+  }
+
   :focus {
     box-shadow: 0 0 0 3px rgba(222, 24, 24, 0.5);
   }
@@ -42,6 +47,11 @@ const BottomCallToActionButtonStyle = styled.button`
 
   :hover {
     background: ${colors.donorHoverActive};
+  }
+
+  :focus:not(:focus-visible) {
+    background: ${colors.donorHoverActive};
+    box-shadow: 0 0 0 3px rgba(222, 24, 24, 0.5) ;
   }
 
   :focus {

--- a/src/components/buttons/ChatButton.js
+++ b/src/components/buttons/ChatButton.js
@@ -15,6 +15,11 @@ const ChatButton = styled.button`
   :focus {
     box-shadow: 0 0 0 3px ${colors.chatButtonFocus};
   }
+
+  :focus:not(:focus-visible) {
+    box-shadow: 0 0 0 3px ${colors.chatButtonFocus};
+    background: ${colors.chatButtonHoverActive};
+  }
 `;
 
 export default ChatButton;

--- a/src/components/buttons/ChatCompleteButton.js
+++ b/src/components/buttons/ChatCompleteButton.js
@@ -15,6 +15,11 @@ const ChatCompleteButton = styled.button`
   :focus {
     box-shadow: 0 0 0 3px ${colors.chatCompleteButtonFocus};
   }
+
+  :focus:not(:focus-visible) {
+    box-shadow: 0 0 0 3px ${colors.chatCompleteButtonFocus};
+    background: ${colors.chatCompleteButtonHoverActive};
+  }
 `;
 
 export default ChatCompleteButton;

--- a/src/components/buttons/ChatSeePostButton.js
+++ b/src/components/buttons/ChatSeePostButton.js
@@ -15,6 +15,11 @@ const ChatSeePostButton = styled.button`
   :focus {
     box-shadow: 0 0 0 3px ${colors.chatSeePostButtonFocus};
   }
+
+  :focus:not(:focus-visible) {
+    box-shadow: 0 0 0 3px ${colors.chatSeePostButtonFocus};
+    background: ${colors.chatSeePostButtonHoverActive};
+  }
 `;
 
 export default ChatSeePostButton;

--- a/src/components/buttons/ChatSuggestDatesButton.js
+++ b/src/components/buttons/ChatSuggestDatesButton.js
@@ -15,6 +15,11 @@ const ChatSuggestDatesButton = styled.button`
   :focus {
     box-shadow: 0 0 0 3px ${colors.chatSuggestDateButtonFocus};
   }
+
+  :focus:not(:focus-visible) {
+    box-shadow: 0 0 0 3px ${colors.chatSuggestDateButtonFocus};
+    background: ${colors.chatSuggestDateButtonHoverActive};
+  }
 `;
 
 export default ChatSuggestDatesButton;

--- a/src/components/buttons/EditProfileButton.js
+++ b/src/components/buttons/EditProfileButton.js
@@ -3,14 +3,22 @@ import { colors } from '@constants/colors';
 
 const EditProfileButton = styled.button`
   background: ${colors.chatButtonBackground};
+
   :active {
     background: ${colors.chatButtonHoverActive};
   }
+
   :hover {
     background: ${colors.chatButtonHoverActive};
   }
+
   :focus {
     box-shadow: 0 0 0 3px ${colors.chatButtonFocus};
+  }
+
+  :focus:not(:focus-visible) {
+    box-shadow: 0 0 0 3px ${colors.chatButtonFocus};
+    background: ${colors.chatButtonHoverActive};
   }
 `;
 

--- a/src/components/buttons/ForgetPasswordButton.js
+++ b/src/components/buttons/ForgetPasswordButton.js
@@ -15,6 +15,11 @@ const ForgetPasswordButton = styled.button`
   :focus {
     box-shadow: 0 0 0 3px rgba(46, 46, 46, 0.5);
   }
+
+  :focus:not(:focus-visible) {
+    box-shadow: 0 0 0 3px rgba(46, 46, 46, 0.5);
+    background: ${colors.loginHoverActive};
+  }
 `;
 
 export default ForgetPasswordButton;

--- a/src/components/buttons/GreySubtleButton.js
+++ b/src/components/buttons/GreySubtleButton.js
@@ -13,6 +13,10 @@ const GreySubtleButton = styled.button`
     background: Transparent;
     box-shadow: 0px 0px 5px 0px rgba(37, 42, 49, 0.16), 0px 2px 8px 0px rgba(37, 42, 49, 0.12);
   }
+
+  :focus:not(:focus-visible) {
+    background: Transparent;
+  }
 `;
 
 export default GreySubtleButton;

--- a/src/components/buttons/RedButton.js
+++ b/src/components/buttons/RedButton.js
@@ -2,18 +2,23 @@ import styled from 'styled-components';
 import { colors } from '@constants/colors';
 
 const RedButton = styled.button`
-  background: ${colors.donorBackground} !important;
+  background: ${colors.donorBackground} ;
 
   :active {
-    background: ${colors.donorHoverActive} !important;
+    background: ${colors.donorHoverActive} ;
   }
 
   :hover {
-    background: ${colors.donorHoverActive} !important;
+    background: ${colors.donorHoverActive} ;
+  }
+
+  :focus:not(:focus-visible) {
+    background: ${colors.donorHoverActive};
+    box-shadow: 0 0 0 3px rgba(222, 24, 24, 0.5) ;
   }
 
   :focus {
-    box-shadow: 0 0 0 3px rgba(222, 24, 24, 0.5) !important;
+    box-shadow: 0 0 0 3px rgba(222, 24, 24, 0.5) ;
   }
 `;
 

--- a/src/components/buttons/RedButton.js
+++ b/src/components/buttons/RedButton.js
@@ -2,23 +2,23 @@ import styled from 'styled-components';
 import { colors } from '@constants/colors';
 
 const RedButton = styled.button`
-  background: ${colors.donorBackground} ;
+  background: ${colors.donorBackground};
 
   :active {
-    background: ${colors.donorHoverActive} ;
+    background: ${colors.donorHoverActive};
   }
 
   :hover {
-    background: ${colors.donorHoverActive} ;
+    background: ${colors.donorHoverActive};
   }
 
   :focus:not(:focus-visible) {
     background: ${colors.donorHoverActive};
-    box-shadow: 0 0 0 3px rgba(222, 24, 24, 0.5) ;
+    box-shadow: 0 0 0 3px rgba(222, 24, 24, 0.5);
   }
 
   :focus {
-    box-shadow: 0 0 0 3px rgba(222, 24, 24, 0.5) ;
+    box-shadow: 0 0 0 3px rgba(222, 24, 24, 0.5);
   }
 `;
 

--- a/src/components/buttons/SaveChangesButton.js
+++ b/src/components/buttons/SaveChangesButton.js
@@ -13,7 +13,12 @@ const SaveChangesButton = styled.button`
   }
 
   :focus {
-    box-shadow: 0 0 0 3px rgba(46, 46, 46, 0.5);
+    box-shadow: 0 0 0 3px ${colors.chatCompleteButtonFocus};
+  }
+
+  :focus:not(:focus-visible) {
+    box-shadow: 0 0 0 3px ${colors.chatCompleteButtonFocus};
+    background: ${colors.saveChangesHoverActive};
   }
 `;
 

--- a/src/components/buttons/ScrollToBottomButton.js
+++ b/src/components/buttons/ScrollToBottomButton.js
@@ -15,6 +15,11 @@ const ScrollToBottomButton = styled.button`
   :focus {
     box-shadow: 0 0 0 3px ${colors.chatScrollToBottomButtonFocus};
   }
+
+  :focus:not(:focus-visible) {
+    box-shadow: 0 0 0 3px ${colors.chatScrollToBottomButtonFocus};
+    background: ${colors.chatScrollToBottomButtonHoverActive};
+  }
 `;
 
 export default ScrollToBottomButton;

--- a/src/components/buttons/SeeMoreButton.js
+++ b/src/components/buttons/SeeMoreButton.js
@@ -26,6 +26,11 @@ const SeeMoreButton = styled.button`
     background: ${colors.seeMoreHoverFocusActive};
     box-shadow: 0px 0px 5px 0px rgba(37, 42, 49, 0.16), 0px 2px 8px 0px rgba(37, 42, 49, 0.12);
   }
+
+  :focus:not(:focus-visible) {
+    background: ${colors.seeMoreHoverFocusActive};
+    box-shadow: 0px 0px 5px 0px rgba(37, 42, 49, 0.16), 0px 2px 8px 0px rgba(37, 42, 49, 0.12);
+  }
 `;
 
 export default SeeMoreButton;

--- a/src/components/buttons/SelectedTimeslotButton.js
+++ b/src/components/buttons/SelectedTimeslotButton.js
@@ -11,6 +11,11 @@ const SelectedTimeslotButton = styled.button`
   :focus {
     box-shadow: 0 0 0 3px ${colors.calendarSelectedFocus};
   }
+
+  :focus:not(:focus-visible) {
+    background: ${colors.calendarSelectedHoverActive};
+    box-shadow: 0 0 0 3px ${colors.calendarSelectedFocus};
+  }
 `;
 
 export default SelectedTimeslotButton;

--- a/src/components/buttons/TimeslotButton.js
+++ b/src/components/buttons/TimeslotButton.js
@@ -13,6 +13,11 @@ const TimeslotButton = styled.button`
   :focus {
     box-shadow: 1px 1px 2px 2px ${colors.calendarUnselectedHoverActiveFocus};
   }
+
+  :focus:not(:focus-visible) {
+    background: ${colors.calendarUnselectedHoverActiveFocus};
+    box-shadow: 1px 1px 2px 2px ${colors.calendarUnselectedHoverActiveFocus};
+  }
 `;
 
 export default TimeslotButton;


### PR DESCRIPTION
In this PR, 
- In Chrome 83, there is a new property called `:focus:not(:focus-visible)` which we didnt override in the orbit library. This PR overrides this property. 