### PR TITLE
Fix wrong query (top wishes)

### DIFF
--- a/src/components/home/modules/algoliaHelpers.js
+++ b/src/components/home/modules/algoliaHelpers.js
@@ -4,7 +4,8 @@ export const getTopNCategoriesFromAlgoliaWithExpireDateTime = async (algoliaInde
   const index = searchClient.initIndex(algoliaIndex);
   return index.search('', {
     facets: ['categories.id'],
-    facetFilters: [['status:pending'], [`expireDateTime >= ${Date.now()}`]],
+    facetFilters: [['status:pending']],
+    // numericFilters: [[`expireDateTime >= ${Date.now()}`]]
   });
 };
 


### PR DESCRIPTION
In this PR,
- Fixed the wrong query for top wishes. But commented out currently because we are allowing expired wishes.