### PR TITLE
Fix undefined email verified property in NPO profile page

### DIFF
--- a/pages/api/emailVerified.js
+++ b/pages/api/emailVerified.js
@@ -1,0 +1,40 @@
+import admin from '@utils/admin-firebase';
+import { cors } from '@utils/middleware/cors';
+
+async function handler(req, res) {
+  await cors(req, res);
+
+  const { method } = req;
+  switch (method) {
+    case 'POST':
+      if (!req.body) {
+        return res.status(400).json({
+          error: {
+            message: 'Bad request. Please check your body.',
+          },
+        });
+      }
+      const userId = req.body.id;
+      const user = await admin
+        .auth()
+        .getUser(userId)
+        .catch(() => {
+          console.error('emailVerified', error);
+          res.status(401).json({
+            error: {
+              message: 'Invalid user ID.',
+            },
+          });
+        });
+      res.json({
+        emailVerified: user.emailVerified,
+      });
+
+      break;
+    default:
+      res.setHeader('Allow', ['POST']);
+      res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+}
+
+export default handler;

--- a/src/components/profile/modules/ProfilePanel.js
+++ b/src/components/profile/modules/ProfilePanel.js
@@ -11,7 +11,7 @@ const ProfilePanelWrapper = styled.div`
   `)};
 `;
 
-const ProfilePanel = ({ user }) => {
+const ProfilePanel = ({ user, isEmailVerified }) => {
   return (
     <ProfilePanelWrapper>
       <ProfileDetails
@@ -20,7 +20,7 @@ const ProfilePanel = ({ user }) => {
         npoOrgAddress={user ? (user.organization ? user.organization.address : '') : ''}
         npoContact={user ? (user.organization ? user.organization.contact : '') : ''}
         name={user ? user.name : ''}
-        isNpoVerifiedByAdmin={user ? user.emailVerified && user.isVerifiedByAdmin : ''}
+        isNpoVerifiedByAdmin={user ? isEmailVerified && user.isVerifiedByAdmin : ''}
         userType={npo}
       />
     </ProfilePanelWrapper>


### PR DESCRIPTION
```
The email verified property of npos are only available within the 
admin auth users.

Since we do not have an API for getting the emailVerified property 
of any users, let's create the api and utilise it within the NPO 
profile page.

Note: we currently only have the API for getting the emailVerifed
property of currently logged in users.
```