### PR TITLE
Chat: Fix chrome issue with negative scrollTop

### DIFF
--- a/src/components/chat/modules/ChatDialogMessages.js
+++ b/src/components/chat/modules/ChatDialogMessages.js
@@ -210,10 +210,11 @@ const ChatDialogMessages = ({ postType, inputRowHeight, isShowPostDetails }) => 
    */
   const scrollHandler = () => {
     // note:
-    // safari browsers' bottom has scrollTop of 0, negative values when scroll up
+    // safari and chrome browsers' bottom has scrollTop of 0, negative values when scroll up
     // other browsers' bottom has scrollTop of scrollHeight - clientHeight
     const bottomScrollTop = isSafari ? 0 : scrollerRef.current.scrollHeight - scrollerRef.current.clientHeight;
-    if (scrollerRef.current.scrollTop < bottomScrollTop) {
+    const currScrollTop = scrollerRef.current.scrollTop;
+    if (currScrollTop < bottomScrollTop && currScrollTop !== 0) {
       setIsShowScrollerButton(true);
     } else {
       setIsShowScrollerButton(false);


### PR DESCRIPTION
Recently chrome has a negative scrollTop with column-reverse when scrolling up, whereas previously only Safari has this issue.

This chrome update causes the scroll to bottom button not disappearing when it is at the bottom of the page.

Note that bottom position will always be zero. Hence,  adding the check that the scrollTop is not zero when setting the scroll to bottom to be visible, we will ensure that the button will not be visible when it is at the bottom of the page.

