### PR TITLE
Add redirect after login

### DIFF
--- a/src/components/navbar/modules/TopRightNavigation.js
+++ b/src/components/navbar/modules/TopRightNavigation.js
@@ -153,7 +153,8 @@ const LoggedInButtons = () => {
 
 const NotLoggedInButtons = () => {
   const router = useRouter();
-  const onLoginClick = () => router.push('/login');
+  const redirectString = router.asPath !== '/' ? `?redirect=${router.asPath}` : '';
+  const onLoginClick = () => router.push(`/login${redirectString}`);
   const onRegisterClick = () => router.push('/register');
   return (
     <>


### PR DESCRIPTION
- Utilised router.asPath instead of router.pathname as router.pathname returns the pathname i.e. `/wish/[wishId]` instead of `/wish/1234245789ryrjewfhbjksd`