### PR TITLE
Refactor structure of search page

### DIFF
--- a/pages/search.js
+++ b/pages/search.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
-import SearchPage from '@components/search/pages/SearchPage';
+
+// components
+import SearchPage from '@pages/search';
 import Header from '@components/header';
 
 const Container = styled.div`

--- a/src/components/navbar/modules/TopLeftNavigation.js
+++ b/src/components/navbar/modules/TopLeftNavigation.js
@@ -3,7 +3,7 @@ import { Stack, ButtonLink } from '@kiwicom/orbit-components/';
 import LogoButton from '../../buttons/LogoButton';
 import { companyLogoImagePath } from '@constants/imagePaths';
 import styled, { css } from 'styled-components';
-import NavSearchBar from '../../search/modules/NavSearchBar';
+import { NavSearchBar } from '@pages/search/components';
 import Link from 'next/link';
 import media from '@kiwicom/orbit-components/lib/utils/mediaQuery';
 

--- a/src/pages/search/components/MobileSearchBar/index.js
+++ b/src/pages/search/components/MobileSearchBar/index.js
@@ -1,6 +1,10 @@
 import React, { useState } from 'react';
+
+// components
 import { Stack, ButtonLink, InputField, Tag, ListChoice } from '@kiwicom/orbit-components/';
 import { Search } from '@kiwicom/orbit-components/lib/icons';
+
+// constants
 import { WISHES, DONATIONS, NPOS } from '@constants/search';
 
 const MobileSearchBar = ({ onEnterPressed }) => {

--- a/src/pages/search/components/NavSearchBar/components/SearchBarV2/index.js
+++ b/src/pages/search/components/NavSearchBar/components/SearchBarV2/index.js
@@ -1,10 +1,14 @@
 import React, { useState } from 'react';
-import { InputField, ButtonLink, Popover, ListChoice, Button, Stack } from '@kiwicom/orbit-components/lib';
-import Close from '@kiwicom/orbit-components/lib/icons/Close';
-import ChevronDown from '@kiwicom/orbit-components/lib/icons/ChevronDown';
 import styled, { css } from 'styled-components';
 import useMediaQuery from '@kiwicom/orbit-components/lib/hooks/useMediaQuery';
 import media from '@kiwicom/orbit-components/lib/utils/mediaQuery';
+
+// components
+import { InputField, ButtonLink, Popover, ListChoice, Stack } from '@kiwicom/orbit-components/lib';
+import Close from '@kiwicom/orbit-components/lib/icons/Close';
+import ChevronDown from '@kiwicom/orbit-components/lib/icons/ChevronDown';
+
+// constants
 import { WISHES } from '@constants/search';
 
 const SearchWrapper = styled.div`

--- a/src/pages/search/components/NavSearchBar/components/index.js
+++ b/src/pages/search/components/NavSearchBar/components/index.js
@@ -1,0 +1,1 @@
+export { default as SearchBar } from './SearchBarV2';

--- a/src/pages/search/components/NavSearchBar/index.js
+++ b/src/pages/search/components/NavSearchBar/index.js
@@ -1,8 +1,12 @@
 import React from 'react';
-import { useRouter } from 'next/router';
-import MobileSearchBar from '../modules/MobileSearchBar';
 
-const SearchPage = () => {
+// components
+import { SearchBar } from './components';
+
+// hooks
+import { useRouter } from 'next/router';
+
+const NavSearchBar = ({ searchDefaultIndex }) => {
   const router = useRouter();
 
   const onEnterPressed = (query, selectedIndex) => {
@@ -15,7 +19,11 @@ const SearchPage = () => {
     }
   };
 
-  return <MobileSearchBar onEnterPressed={onEnterPressed} />;
+  return (
+    <>
+      <SearchBar onEnterPressed={onEnterPressed} defaultIndex={searchDefaultIndex} />
+    </>
+  );
 };
 
-export default SearchPage;
+export default NavSearchBar;

--- a/src/pages/search/components/NavSearchBarDropdownList/components/AlgoliaSearchBar/index.js
+++ b/src/pages/search/components/NavSearchBarDropdownList/components/AlgoliaSearchBar/index.js
@@ -1,6 +1,10 @@
 import React, { useState } from 'react';
+
+// components
 import { InputField, ButtonLink } from '@kiwicom/orbit-components/lib';
 import Close from '@kiwicom/orbit-components/lib/icons/Close';
+
+// hooks
 import useDebouncedEffect from '@utils/hooks/useDebouncedEffect';
 
 // Added 500ms of delay so that search does not incur so much request.

--- a/src/pages/search/components/NavSearchBarDropdownList/components/Hits/index.js
+++ b/src/pages/search/components/NavSearchBarDropdownList/components/Hits/index.js
@@ -1,5 +1,9 @@
 import React from 'react';
+
+// components
 import { ListChoice } from '@kiwicom/orbit-components/lib';
+
+// hooks
 import { useRouter } from 'next/router';
 
 const Hits = ({ hits, type }) => {

--- a/src/pages/search/components/NavSearchBarDropdownList/components/index.js
+++ b/src/pages/search/components/NavSearchBarDropdownList/components/index.js
@@ -1,0 +1,2 @@
+export { default as SearchBar } from './AlgoliaSearchBar';
+export { default as Hits } from './Hits';

--- a/src/pages/search/components/NavSearchBarDropdownList/index.js
+++ b/src/pages/search/components/NavSearchBarDropdownList/index.js
@@ -1,11 +1,14 @@
 import React, { useRef, useState } from 'react';
-import { InstantSearch, connectSearchBox, Index, Configure, connectHits } from 'react-instantsearch-dom';
-import SearchBar from './AlgoliaSearchBar';
-import Hits from './Hits';
 import styled from 'styled-components';
+
+// components
+import { InstantSearch, connectSearchBox, Index, Configure, connectHits } from 'react-instantsearch-dom';
+import { SearchBar, Hits } from './components';
 import { Text } from '@kiwicom/orbit-components/lib';
-import { MAXIMUM_SEARCH_DESKTOP } from '@constants/search';
 import Popover from 'react-tiny-popover';
+
+// constants and utils
+import { MAXIMUM_SEARCH_DESKTOP } from '@constants/search';
 import { searchClient } from '@utils/algolia';
 
 const CustomSearchBox = connectSearchBox(SearchBar);
@@ -20,7 +23,7 @@ const ContentContainer = styled.div`
   padding: 0px 10px 8px 10px;
 `;
 
-const NavSearchBar = () => {
+const NavSearchBarDropdownList = () => {
   const inputRef = useRef(null);
   const [isOpen, setIsOpen] = useState(false);
 
@@ -74,4 +77,4 @@ const NavSearchBar = () => {
   );
 };
 
-export default NavSearchBar;
+export default NavSearchBarDropdownList;

--- a/src/pages/search/components/index.js
+++ b/src/pages/search/components/index.js
@@ -1,0 +1,3 @@
+export { default as MobileSearchBar } from './MobileSearchBar';
+export { default as NavSearchBar } from './NavSearchBar';
+export { default as NavSearchBarDropdownList } from './NavSearchBarDropdownList';

--- a/src/pages/search/index.js
+++ b/src/pages/search/index.js
@@ -1,8 +1,12 @@
-import React, { useState } from 'react';
-import SearchBar from '../modules/SearchBarV2';
+import React from 'react';
+
+// components
+import { MobileSearchBar } from './components';
+
+// hooks
 import { useRouter } from 'next/router';
 
-const NavSearchBar = ({ searchDefaultIndex }) => {
+const SearchPage = () => {
   const router = useRouter();
 
   const onEnterPressed = (query, selectedIndex) => {
@@ -15,11 +19,7 @@ const NavSearchBar = ({ searchDefaultIndex }) => {
     }
   };
 
-  return (
-    <>
-      <SearchBar onEnterPressed={onEnterPressed} defaultIndex={searchDefaultIndex} />
-    </>
-  );
+  return <MobileSearchBar onEnterPressed={onEnterPressed} />;
 };
 
-export default NavSearchBar;
+export default SearchPage;


### PR DESCRIPTION
Note: in the future, may need to move `NavSearchBar` into `src/components` since `TopLeftNavigation` uses it.